### PR TITLE
Update auth environment variables

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -34,7 +34,7 @@ locals {
       FARGATE_EXECUTOR_SECURITY_GROUPS = module.fargate_sg.security_group_id,
       SINGLE_PLAYER                    = var.polytomic_single_player,
       WORKOS_API_KEY                   = var.polytomic_workos_api_key,
-      WORKOS_CLIENT_ID                 = var.polytomic_react_app_workos_client_id,
+      WORKOS_CLIENT_ID                 = var.polytomic_workos_client_id,
     }
   }
 }

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -18,7 +18,7 @@ locals {
       DEPLOYMENT_KEY                   = var.polytomic_deployment_key,
       DATABASE_URL                     = local.database_url,
       REDIS_URL                        = local.redis_url,
-      POLYTOMIC_URL                    = var.polytomic_url == "" ? "http://${aws_alb.main.dns_name}/auth" : var.polytomic_url,
+      POLYTOMIC_URL                    = var.polytomic_url == "" ? "http://${aws_alb.main.dns_name}/" : var.polytomic_url,
       EXECUTION_LOG_BUCKET             = "${var.prefix}-${local.polytomic_execution_bucket}",
       EXECUTION_LOG_REGION             = var.region,
       EXPORT_QUERY_BUCKET              = "${var.prefix}-${local.polytomic_export_bucket}",
@@ -34,7 +34,7 @@ locals {
       FARGATE_EXECUTOR_SECURITY_GROUPS = module.fargate_sg.security_group_id,
       SINGLE_PLAYER                    = var.polytomic_single_player,
       WORKOS_API_KEY                   = var.polytomic_workos_api_key,
-      REACT_APP_WORKOS_CLIENT_ID       = var.polytomic_react_app_workos_client_id,
+      WORKOS_CLIENT_ID                 = var.polytomic_react_app_workos_client_id,
     }
   }
 }

--- a/terraform/modules/ecs/vars.tf
+++ b/terraform/modules/ecs/vars.tf
@@ -61,8 +61,23 @@ variable "polytomic_workos_api_key" {
   default     = ""
 }
 
-variable "polytomic_react_app_workos_client_id" {
+variable "polytomic_workos_client_id" {
   description = "The WorkOS client ID"
+  default     = ""
+}
+
+variable "polytomic_workspace_name" {
+  description = "Name of first Polytomic workspace"
+  default     = ""
+}
+
+variable "polytomic_sso_domain" {
+  description = "Domain for SSO users of first Polytomic workspace; ie, example.com."
+  default     = ""
+}
+
+variable "polytomic_workos_org_id" {
+  description = "WorkOS organization ID for workspace SSO"
   default     = ""
 }
 
@@ -304,19 +319,4 @@ variable "tags" {
   description = "A map of tags to add to all resources"
   type        = map(string)
   default     = {}
-}
-
-variable "polytomic_workspace_name" {
-  description = "Name of first Polytomic workspace"
-  default     = ""
-}
-
-variable "polytomic_sso_domain" {
-  description = "Domain for SSO users of first Polytomic workspace; ie, example.com."
-  default     = ""
-}
-
-variable "polytomic_workos_org_id" {
-  description = "WorkOS organization ID for workspace SSO"
-  default     = ""
 }


### PR DESCRIPTION
The WorkOS Client ID environment variable was renamed starting in
rel2022.06.30.01.

Additionally, the `POLYTOMIC_URL` points to the "root" URL for the
installation.