### PR TITLE
Increase ulimit on sync and worker tasks

### DIFF
--- a/terraform/modules/ecs/task-definitions/sync.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/sync.json.tftpl
@@ -28,5 +28,12 @@
     }],
     "memoryReservation": 2048,
     "image": "${image}",
-    "name": "sync"
+    "name": "sync",
+     "ulimits": [
+      {
+        "name": "nofile",
+        "softLimit": 1024000,
+        "hardLimit": 1024000
+      }
+    ]
 }]

--- a/terraform/modules/ecs/task-definitions/worker.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/worker.json.tftpl
@@ -28,5 +28,12 @@
     }],
     "memoryReservation": 2048,
     "image": "${image}",
-    "name": "worker"
+    "name": "worker",
+    "ulimits": [
+      {
+        "name": "nofile",
+        "softLimit": 1024000,
+        "hardLimit": 1024000
+      }
+    ]
 }]


### PR DESCRIPTION
Verified set properly using session manager

```
➜  aws ecs execute-command  \
--region   xxxxxxxxx  \
--cluster xxxxxxxxx \
--task xxxxxxxxx  \
--container worker \
--command "/bin/bash" \
--interactive

The Session Manager plugin was installed successfully. Use the AWS CLI to start a session.


Starting session with SessionId: ecs-execute-command-0467f1856491d83c8
root@ip-10-0-1-166:~# ulimit -Sn
1024000
root@ip-10-0-1-166:~# ulimit -Hn
1024000
root@ip-10-0-1-166:~#
```