### PR TITLE
Ignore changes to ALB listener

### DIFF
--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -181,9 +181,9 @@ module "polytomic-ecs" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.22.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.1.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
 
 ## Resources
 

--- a/terraform/modules/ecs/alb.tf
+++ b/terraform/modules/ecs/alb.tf
@@ -37,4 +37,8 @@ resource "aws_alb_listener" "http" {
     target_group_arn = aws_alb_target_group.polytomic.id
     type             = "forward"
   }
+
+  lifecycle {
+    ignore_changes = [default_action]
+  }
 }


### PR DESCRIPTION
We add a `default_action` on the module's ALB listener to forward to the app over port 80. We do this to be unopinionated on TLS termination. This can become an annoyance for folks that change this to redirect to port 443. This change force terraform to ignores change to the `default_action`