### PR TITLE
Revert "Ignore changes to ALB listener"

### DIFF
--- a/terraform/modules/ecs/alb.tf
+++ b/terraform/modules/ecs/alb.tf
@@ -37,8 +37,4 @@ resource "aws_alb_listener" "http" {
     target_group_arn = aws_alb_target_group.polytomic.id
     type             = "forward"
   }
-
-  lifecycle {
-    ignore_changes = [default_action]
-  }
 }


### PR DESCRIPTION
Reverts polytomic/on-premises#35

ECS tasks require a valid forwarder this breaks updates to the web service. Reverting for now.