### PR TITLE
Disable minor version upgrades outside of terraform by default

### DIFF
--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -254,6 +254,7 @@ module "polytomic-ecs" {
 | <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS profile to use | `string` | `"default"` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Bucket prefix | `string` | `"polytomic"` | no |
 | <a name="input_database_allocated_storage"></a> [database\_allocated\_storage](#input\_database\_allocated\_storage) | Database allocated storage | `number` | `20` | no |
+| <a name="input_database_auto_minor_version_upgrade"></a> [database\_auto\_minor\_version\_upgrade](#input\_database\_auto\_minor\_version\_upgrade) | Database auto minor version upgrade | `bool` | `false` | no |
 | <a name="input_database_backup_retention"></a> [database\_backup\_retention](#input\_database\_backup\_retention) | Database backup retention | `number` | `30` | no |
 | <a name="input_database_backup_window"></a> [database\_backup\_window](#input\_database\_backup\_window) | Database backup window | `string` | `"03:00-06:00"` | no |
 | <a name="input_database_create_cloudwatch_log_group"></a> [database\_create\_cloudwatch\_log\_group](#input\_database\_create\_cloudwatch\_log\_group) | Database create cloudwatch log group | `bool` | `true` | no |

--- a/terraform/modules/ecs/database.tf
+++ b/terraform/modules/ecs/database.tf
@@ -6,13 +6,14 @@ module "database" {
   identifier = "${var.prefix}-database"
 
   # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
-  engine                = var.database_engine
-  engine_version        = var.database_engine_version
-  family                = var.database_family
-  major_engine_version  = var.database_major_engine_version
-  instance_class        = var.database_instance_class
-  allocated_storage     = var.database_allocated_storage
-  max_allocated_storage = var.database_max_allocated_storage
+  engine                     = var.database_engine
+  engine_version             = var.database_engine_version
+  auto_minor_version_upgrade = var.database_auto_minor_version_upgrade
+  family                     = var.database_family
+  major_engine_version       = var.database_major_engine_version
+  instance_class             = var.database_instance_class
+  allocated_storage          = var.database_allocated_storage
+  max_allocated_storage      = var.database_max_allocated_storage
 
   # NOTE: Do NOT use 'user' as the value for 'username' as it throws:
   # "Error creating DB Instance: InvalidParameterValue: MasterUsername

--- a/terraform/modules/ecs/vars.tf
+++ b/terraform/modules/ecs/vars.tf
@@ -303,6 +303,11 @@ variable "database_engine" {
   default     = "postgres"
 }
 
+variable "database_auto_minor_version_upgrade" {
+  description = "Database auto minor version upgrade"
+  default     = false
+}
+
 variable "database_engine_version" {
   description = "Database engine version"
   default     = "14.1"


### PR DESCRIPTION
I think the best option here is to handle **all** version upgrades inside of terraform.

Fixes #31 