### PR TITLE
Add changelog for releases >1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 1.0.0 (18 May 2023)
+* Initial release


### PR DESCRIPTION
This will be our official 1.0.0 release. We'll maintain a changelog and semantic versioning for all releases.