### PR TITLE
Don't use logger sidecar now that we are running vector internally

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -88,7 +88,7 @@ locals {
     region                 = var.region,
     polytomic_port         = var.polytomic_port,
     mount_path             = var.polytomic_data_path,
-    polytomic_logger       = var.polytomic_use_logger,
+    polytomic_logger       = false
     polytomic_logger_image = var.polytomic_logger_image,
 
     polytomic_dd_agent       = var.polytomic_use_dd_agent,


### PR DESCRIPTION
Now that https://github.com/polytomic/on-premises/commit/46acade6dbfba4d1be91847c6997ec18ef625c31 is merged, I think we always want to prevent use of the logger sidecar so we don't duplicate logs. I'll eventually rip the sidecar out of the task definitions but this is low impact for now.