### PR TITLE
Provide redundancy for sync containers

### DIFF
--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -324,6 +324,7 @@ module "polytomic-ecs" {
 | <a name="input_polytomic_record_log_disabled"></a> [polytomic\_record\_log\_disabled](#input\_polytomic\_record\_log\_disabled) | Globally disable record logging for this deployment | `bool` | `false` | no |
 | <a name="input_polytomic_resource_scheduler_cpu"></a> [polytomic\_resource\_scheduler\_cpu](#input\_polytomic\_resource\_scheduler\_cpu) | CPU units for the scheduler container | `number` | `1024` | no |
 | <a name="input_polytomic_resource_scheduler_memory"></a> [polytomic\_resource\_scheduler\_memory](#input\_polytomic\_resource\_scheduler\_memory) | Memory units for the scheduler container | `number` | `2048` | no |
+| <a name="input_polytomic_resource_sync_count"></a> [polytomic\_resource\_sync\_count](#input\_polytomic\_resource\_sync\_count) | Number of sync containers to run | `number` | `2` | no |
 | <a name="input_polytomic_resource_sync_cpu"></a> [polytomic\_resource\_sync\_cpu](#input\_polytomic\_resource\_sync\_cpu) | CPU units for the sync container | `number` | `4096` | no |
 | <a name="input_polytomic_resource_sync_memory"></a> [polytomic\_resource\_sync\_memory](#input\_polytomic\_resource\_sync\_memory) | Memory units for the sync container | `number` | `8192` | no |
 | <a name="input_polytomic_resource_web_cpu"></a> [polytomic\_resource\_web\_cpu](#input\_polytomic\_resource\_web\_cpu) | CPU units for the web container | `number` | `2048` | no |

--- a/terraform/modules/ecs/ecs-tasks.tf
+++ b/terraform/modules/ecs/ecs-tasks.tf
@@ -190,7 +190,7 @@ resource "aws_ecs_service" "sync" {
   name            = "${var.prefix}-sync"
   cluster         = var.ecs_cluster_name == "" ? module.ecs[0].cluster_arn : data.aws_ecs_cluster.cluster[0].arn
   task_definition = aws_ecs_task_definition.sync.arn
-  desired_count   = 1
+  desired_count   = 2
 
   enable_execute_command = true
   platform_version       = "1.4.0"

--- a/terraform/modules/ecs/ecs-tasks.tf
+++ b/terraform/modules/ecs/ecs-tasks.tf
@@ -190,7 +190,7 @@ resource "aws_ecs_service" "sync" {
   name            = "${var.prefix}-sync"
   cluster         = var.ecs_cluster_name == "" ? module.ecs[0].cluster_arn : data.aws_ecs_cluster.cluster[0].arn
   task_definition = aws_ecs_task_definition.sync.arn
-  desired_count   = 2
+  desired_count   = ${var.polytomic_resource_sync_count}
 
   enable_execute_command = true
   platform_version       = "1.4.0"

--- a/terraform/modules/ecs/ecs-tasks.tf
+++ b/terraform/modules/ecs/ecs-tasks.tf
@@ -190,7 +190,7 @@ resource "aws_ecs_service" "sync" {
   name            = "${var.prefix}-sync"
   cluster         = var.ecs_cluster_name == "" ? module.ecs[0].cluster_arn : data.aws_ecs_cluster.cluster[0].arn
   task_definition = aws_ecs_task_definition.sync.arn
-  desired_count   = ${var.polytomic_resource_sync_count}
+  desired_count   = var.polytomic_resource_sync_count
 
   enable_execute_command = true
   platform_version       = "1.4.0"

--- a/terraform/modules/ecs/vars.tf
+++ b/terraform/modules/ecs/vars.tf
@@ -157,6 +157,11 @@ variable "polytomic_resource_scheduler_memory" {
   default     = 2048 // 2 GB
 }
 
+variable "polytomic_resource_sync_count" {
+  description = "Number of sync containers to run"
+  default     = 2
+}
+
 variable "polytomic_resource_sync_cpu" {
   description = "CPU units for the sync container"
   default     = 4096 // 4 vCPU


### PR DESCRIPTION
The sync container is responsible for running many different types of tasks; as such, we should provide redundancy for it.