### PR TITLE
Lock database module version

### DIFF
--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -191,9 +191,9 @@ module "polytomic-ecs" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.22.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.1.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
 
 ## Resources
 
@@ -242,7 +242,7 @@ module "polytomic-ecs" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_database"></a> [database](#module\_database) | terraform-aws-modules/rds/aws | n/a |
+| <a name="module_database"></a> [database](#module\_database) | terraform-aws-modules/rds/aws | 5.9.0 |
 | <a name="module_database_sg"></a> [database\_sg](#module\_database\_sg) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_ecs"></a> [ecs](#module\_ecs) | terraform-aws-modules/ecs/aws | <5.0.0 |
 | <a name="module_ecs-alerts-worker"></a> [ecs-alerts-worker](#module\_ecs-alerts-worker) | ../monitoring/ecs-alerts | n/a |

--- a/terraform/modules/ecs/database.tf
+++ b/terraform/modules/ecs/database.tf
@@ -1,5 +1,6 @@
 module "database" {
-  source = "terraform-aws-modules/rds/aws"
+  source  = "terraform-aws-modules/rds/aws"
+  version = "5.9.0"
 
   count = var.database_endpoint == "" ? 1 : 0
 


### PR DESCRIPTION
The recent  `6.0.0` version of the database module required aws_provider >= 5.0.0. Conversely, the Redis module requires aws_provider < 5.0.0. There's currently an [open issue](https://github.com/umotif-public/terraform-aws-elasticache-redis/issues/45) on the upstream redis module to support version 5. I reckon we ought to hold out to see if that gets fixed. If it's not resolved in a reasonable amount of time, we can fork the module. 

This will fix the immediate dependency deadlock in the meantime.