### PR TITLE
Add `Name` tags to resources

### DIFF
--- a/terraform/modules/ecs/alb.tf
+++ b/terraform/modules/ecs/alb.tf
@@ -10,7 +10,12 @@ resource "aws_alb" "main" {
   security_groups = local.lb_sgs
   internal        = var.load_balancer_internal
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-alb"
+    }
+  )
 
 }
 
@@ -20,7 +25,12 @@ resource "aws_alb_target_group" "polytomic" {
   protocol    = "HTTP"
   vpc_id      = var.vpc_id == "" ? module.vpc[0].vpc_id : var.vpc_id
   target_type = "ip"
-  tags        = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-tg"
+    }
+  )
 
   health_check {
     healthy_threshold   = "3"
@@ -43,7 +53,12 @@ resource "aws_alb_listener" "http" {
   load_balancer_arn = aws_alb.main.id
   port              = 80
   protocol          = "HTTP"
-  tags              = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-http-listener"
+    }
+  )
 
 
   dynamic "default_action" {

--- a/terraform/modules/ecs/buckets.tf
+++ b/terraform/modules/ecs/buckets.tf
@@ -40,5 +40,10 @@ module "s3_bucket" {
     }
   }
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-${var.bucket_prefix}${each.key}"
+    }
+  )
 }

--- a/terraform/modules/ecs/database.tf
+++ b/terraform/modules/ecs/database.tf
@@ -44,6 +44,11 @@ module "database" {
   monitoring_interval                   = var.database_monitoring_interval
   monitoring_role_name                  = var.database_monitoring_role_name
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-database"
+    }
+  )
 
 }

--- a/terraform/modules/ecs/ecs-cluster.tf
+++ b/terraform/modules/ecs/ecs-cluster.tf
@@ -30,7 +30,12 @@ module "ecs" {
     }
   }
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-cluster"
+    }
+  )
 }
 
 data "aws_ecs_cluster" "cluster" {

--- a/terraform/modules/ecs/ecs-tasks.tf
+++ b/terraform/modules/ecs/ecs-tasks.tf
@@ -8,7 +8,11 @@ resource "aws_ecs_task_definition" "web" {
 
   task_role_arn      = aws_iam_role.polytomic_ecs_task_role.arn
   execution_role_arn = aws_iam_role.polytomic_ecs_execution_role.arn
-  tags               = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-web"
+  })
 
 
   runtime_platform {
@@ -43,7 +47,11 @@ resource "aws_ecs_task_definition" "worker" {
 
   task_role_arn      = aws_iam_role.polytomic_ecs_task_role.arn
   execution_role_arn = aws_iam_role.polytomic_ecs_execution_role.arn
-  tags               = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-worker"
+  })
 
 
   runtime_platform {
@@ -78,7 +86,11 @@ resource "aws_ecs_task_definition" "sync" {
 
   task_role_arn      = aws_iam_role.polytomic_ecs_task_role.arn
   execution_role_arn = aws_iam_role.polytomic_ecs_execution_role.arn
-  tags               = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-sync"
+  })
 
 
   runtime_platform {
@@ -113,7 +125,11 @@ resource "aws_ecs_task_definition" "scheduler" {
 
   task_role_arn      = aws_iam_role.polytomic_ecs_task_role.arn
   execution_role_arn = aws_iam_role.polytomic_ecs_execution_role.arn
-  tags               = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-scheduler"
+  })
 
 
   runtime_platform {
@@ -149,7 +165,11 @@ resource "aws_ecs_service" "web" {
   platform_version                  = "1.4.0"
 
   launch_type = "FARGATE"
-  tags        = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-web"
+  })
 
   propagate_tags = "TASK_DEFINITION"
 
@@ -179,7 +199,11 @@ resource "aws_ecs_service" "worker" {
   platform_version       = "1.4.0"
 
   launch_type = "FARGATE"
-  tags        = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-worker"
+  })
 
 
   propagate_tags = "TASK_DEFINITION"
@@ -201,7 +225,11 @@ resource "aws_ecs_service" "sync" {
   platform_version       = "1.4.0"
 
   launch_type = "FARGATE"
-  tags        = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-sync"
+  })
 
   propagate_tags = "TASK_DEFINITION"
 
@@ -224,7 +252,11 @@ resource "aws_ecs_service" "scheduler" {
   platform_version       = "1.4.0"
 
   launch_type = "FARGATE"
-  tags        = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-scheduler"
+  })
 
   propagate_tags = "TASK_DEFINITION"
 

--- a/terraform/modules/ecs/efs.tf
+++ b/terraform/modules/ecs/efs.tf
@@ -9,5 +9,10 @@ module "efs" {
 
   allowed_security_group_ids = [module.efs_sg.security_group_id, module.fargate_sg.security_group_id]
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-efs"
+    }
+  )
 }

--- a/terraform/modules/ecs/iam.tf
+++ b/terraform/modules/ecs/iam.tf
@@ -66,7 +66,11 @@ data "aws_iam_policy_document" "ecs_tasks_assume_role" {
 resource "aws_iam_role" "polytomic_ecs_task_role" {
   name               = "${var.prefix}-ecs-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume_role.json
-  tags               = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-ecs-task-role"
+  })
 }
 
 
@@ -99,7 +103,11 @@ data "aws_iam_policy_document" "polytomic_execution" {
 resource "aws_iam_role" "polytomic_ecs_execution_role" {
   name               = "${var.prefix}-ecs-execution-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume_role.json
-  tags               = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-ecs-execution-role"
+  })
 }
 
 
@@ -140,7 +148,11 @@ resource "aws_iam_role" "polytomic_stats_reporter_role" {
   count              = var.enable_stats ? 1 : 0
   name               = "${var.prefix}-stats-reporter-role"
   assume_role_policy = data.aws_iam_policy_document.events_assume_role_policy.json
-  tags               = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-stats-reporter-role"
+  })
 }
 
 

--- a/terraform/modules/ecs/logs.tf
+++ b/terraform/modules/ecs/logs.tf
@@ -5,5 +5,10 @@ module "log_group" {
   name              = "${var.prefix}-polytomic-logs"
   retention_in_days = var.log_retention_days
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-polytomic-logs"
+    }
+  )
 }

--- a/terraform/modules/ecs/redis.tf
+++ b/terraform/modules/ecs/redis.tf
@@ -27,7 +27,12 @@ module "redis" {
 
   ingress_cidr_blocks = local.private_subnet_cidrs
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-redis"
+    }
+  )
 }
 
 resource "random_password" "redis" {

--- a/terraform/modules/ecs/security-groups.tf
+++ b/terraform/modules/ecs/security-groups.tf
@@ -18,7 +18,12 @@ module "database_sg" {
     },
   ]
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-database-sg"
+    }
+  )
 }
 
 
@@ -49,7 +54,12 @@ module "fargate_sg" {
     },
   ]
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-fargate_task"
+    }
+  )
 }
 
 
@@ -71,7 +81,12 @@ module "efs_sg" {
     },
   ]
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-efs"
+    }
+  )
 }
 
 
@@ -111,6 +126,11 @@ module "lb_sg" {
     },
   ]
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-lb"
+    }
+  )
 }
 

--- a/terraform/modules/ecs/stats.tf
+++ b/terraform/modules/ecs/stats.tf
@@ -27,7 +27,11 @@ resource "aws_ecs_task_definition" "stats_reporter" {
 
   task_role_arn      = aws_iam_role.polytomic_ecs_task_role.arn
   execution_role_arn = aws_iam_role.polytomic_ecs_execution_role.arn
-  tags               = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-stats-reporter"
+  })
 
 
 

--- a/terraform/modules/ecs/vpc.tf
+++ b/terraform/modules/ecs/vpc.tf
@@ -29,5 +29,10 @@ resource "aws_vpc_endpoint" "s3" {
   vpc_id          = module.vpc[0].vpc_id
   service_name    = "com.amazonaws.${var.region}.s3"
   route_table_ids = module.vpc[0].private_route_table_ids
-  tags            = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-s3-endpoint"
+    }
+  )
 }


### PR DESCRIPTION
This merges in an additional `Name` tag to all of the resources we create. This can be helpful for things such as cost attribution.