### PR TITLE
Add workload identity service account and role

### DIFF
--- a/helm/charts/polytomic/templates/_helpers.tpl
+++ b/helm/charts/polytomic/templates/_helpers.tpl
@@ -109,6 +109,7 @@ Construct Polytomic Configuration
 ROOT_USER: {{ .Values.polytomic.auth.root_user | quote }}
 DEPLOYMENT: {{ .Values.polytomic.deployment.name | quote }}
 DEPLOYMENT_KEY: {{ .Values.polytomic.deployment.key | quote }}
+DEPLOYMENT_API_KEY: {{ .Values.polytomic.deployment.api_key | quote }}
 {{ if .Values.polytomic.postgres.ssl -}}
 DATABASE_URL: postgres://{{ .Values.polytomic.postgres.username }}{{- if .Values.polytomic.postgres.password}}:{{ .Values.polytomic.postgres.password }}{{- end}}@{{ .Values.polytomic.postgres.host }}:{{ .Values.polytomic.postgres.port }}/{{ .Values.polytomic.postgres.database }}
 {{- else}}
@@ -209,5 +210,10 @@ WORKOS_CLIENT_ID: {{ .Values.polytomic.auth.workos_client_id | quote }}
 ZENDESK_CLIENT_ID: {{ .Values.polytomic.zendesk_client_id | quote }}
 ZENDESK_CLIENT_SECRET: {{ .Values.polytomic.zendesk_client_secret | quote }}
 hubspot_scopes_v2: "true"
+
+{{- if .Values.polytomic.s3.gcs }}
+POLYTOMIC_USE_GCS: "true"
+{{- end }}
+
 
 {{- end }}

--- a/terraform/examples/gke-complete/cluster/outputs.tf
+++ b/terraform/examples/gke-complete/cluster/outputs.tf
@@ -23,6 +23,11 @@ output "cluster_sa" {
   value       = module.gke_cluster_service_account.email
 }
 
+output "workload_identity_user_sa" {
+  description = "Workload identity user service account"
+  value       = module.gke_cluster_service_account.workload_identity_user_sa_email
+}
+
 output "redis_auth_string" {
   value     = module.gke.redis_auth_string
   sensitive = true

--- a/terraform/modules/gke-cluster-sa/README.md
+++ b/terraform/modules/gke-cluster-sa/README.md
@@ -20,7 +20,10 @@ No modules.
 | [google_project_iam_member.cluster_service_account-metric_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cluster_service_account-monitoring_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cluster_service_account-resourceMetadata-writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.storage-role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.workload-identity-role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_account.cluster_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account.workload-identity-user-sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 
 ## Inputs
 
@@ -33,3 +36,4 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_email"></a> [email](#output\_email) | Service account email |
+| <a name="output_workload_identity_user_sa_email"></a> [workload\_identity\_user\_sa\_email](#output\_workload\_identity\_user\_sa\_email) | Workload identity user service account email |

--- a/terraform/modules/gke-cluster-sa/main.tf
+++ b/terraform/modules/gke-cluster-sa/main.tf
@@ -28,3 +28,18 @@ resource "google_project_iam_member" "cluster_service_account-resourceMetadata-w
   member  = "serviceAccount:${google_service_account.cluster_service_account.email}"
 }
 
+resource "google_service_account" "workload-identity-user-sa" {
+  project      = var.project_id
+  account_id   = "workload-identity-user-sa"
+  display_name = "Service Account For Workload Identity"
+}
+resource "google_project_iam_member" "storage-role" {
+  project = var.project_id
+  role    = "roles/storage.objectAdmin"
+  member  = "serviceAccount:${google_service_account.workload-identity-user-sa.email}"
+}
+resource "google_project_iam_member" "workload-identity-role" {
+  project = var.project_id
+  role    = "roles/iam.workloadIdentityUser"
+  member  = "serviceAccount:${var.project_id}.svc.id.goog[polytomic/polytomic]"
+}

--- a/terraform/modules/gke-cluster-sa/outputs.tf
+++ b/terraform/modules/gke-cluster-sa/outputs.tf
@@ -2,3 +2,8 @@ output "email" {
   description = "Service account email"
   value       = google_service_account.cluster_service_account.email
 }
+
+output "workload_identity_user_sa_email" {
+  description = "Workload identity user service account email"
+  value       = google_service_account.workload-identity-user-sa.email
+}

--- a/terraform/modules/gke-helm/README.md
+++ b/terraform/modules/gke-helm/README.md
@@ -22,6 +22,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_polytomic_api_key"></a> [polytomic\_api\_key](#input\_polytomic\_api\_key) | The api key for the polytomic deployment | `string` | `""` | no |
 | <a name="input_polytomic_bucket"></a> [polytomic\_bucket](#input\_polytomic\_bucket) | The operational bucket for the polytomic deployment | `any` | n/a | yes |
 | <a name="input_polytomic_cert_name"></a> [polytomic\_cert\_name](#input\_polytomic\_cert\_name) | The name of the certificate to use for the polytomic deployment | `any` | n/a | yes |
 | <a name="input_polytomic_deployment"></a> [polytomic\_deployment](#input\_polytomic\_deployment) | The name of the polytomic deployment | `any` | n/a | yes |
@@ -32,6 +33,7 @@ No modules.
 | <a name="input_polytomic_image_tag"></a> [polytomic\_image\_tag](#input\_polytomic\_image\_tag) | The tag to use for the polytomic container | `any` | n/a | yes |
 | <a name="input_polytomic_ip_name"></a> [polytomic\_ip\_name](#input\_polytomic\_ip\_name) | The name of the ip to use for the polytomic deployment | `any` | n/a | yes |
 | <a name="input_polytomic_root_user"></a> [polytomic\_root\_user](#input\_polytomic\_root\_user) | The root user for the polytomic deployment | `string` | `"root"` | no |
+| <a name="input_polytomic_service_account"></a> [polytomic\_service\_account](#input\_polytomic\_service\_account) | Workload identity service account for the polytomic deployment | `any` | n/a | yes |
 | <a name="input_polytomic_url"></a> [polytomic\_url](#input\_polytomic\_url) | The url for the polytomic deployment | `any` | n/a | yes |
 | <a name="input_postgres_host"></a> [postgres\_host](#input\_postgres\_host) | The host for the postgres deployment | `any` | n/a | yes |
 | <a name="input_postgres_password"></a> [postgres\_password](#input\_postgres\_password) | The password for the postgres deployment | `any` | n/a | yes |

--- a/terraform/modules/gke-helm/main.tf
+++ b/terraform/modules/gke-helm/main.tf
@@ -27,13 +27,19 @@ image:
   repository: ${var.polytomic_image}
   tag: ${var.polytomic_image_tag}
 
+serviceAccount.Annotations:
+  iam.gke.io/gcp-service-account: ${var.polytomic_service_account}
 
 polytomic:
   deployment:
     name: ${var.polytomic_deployment}
     key: ${var.polytomic_deployment_key}
+    api_key: ${var.polytomic_api_key}
+
   
   auth:
+    methods:
+      - google
     root_user: ${var.polytomic_root_user}
     url: https://${var.polytomic_url}
     single_player: false
@@ -54,6 +60,7 @@ polytomic:
   s3:
     operational_bucket: gs://${var.polytomic_bucket}
     record_log_bucket: ${var.polytomic_bucket}
+    gcs: true
   
   jobs:
     image: ${var.polytomic_image}

--- a/terraform/modules/gke-helm/vars.tf
+++ b/terraform/modules/gke-helm/vars.tf
@@ -14,6 +14,11 @@ variable "polytomic_deployment_key" {
   description = "The key for the polytomic deployment"
 }
 
+variable "polytomic_api_key" {
+  default     = ""
+  description = "The api key for the polytomic deployment"
+}
+
 variable "polytomic_url" {
   description = "The url for the polytomic deployment"
 }
@@ -62,4 +67,7 @@ variable "postgres_host" {
 
 variable "polytomic_bucket" {
   description = "The operational bucket for the polytomic deployment"
+}
+variable "polytomic_service_account" {
+  description = "Workload identity service account for the polytomic deployment"
 }


### PR DESCRIPTION
This commit adds [workload identity](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) to our gke module so that pods can read/write objects to GCS. This can be used as an established pattern for other IAM permissions in the future.

Additionally, there's a few additions to the helm chart.