### PR TITLE
Handle log groups with terraform instead of delegating to log driver

### DIFF
--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -246,6 +246,7 @@ module "polytomic-ecs" {
 | <a name="module_database_sg"></a> [database\_sg](#module\_database\_sg) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_ecs"></a> [ecs](#module\_ecs) | terraform-aws-modules/ecs/aws | <5.0.0 |
 | <a name="module_ecs-alerts-worker"></a> [ecs-alerts-worker](#module\_ecs-alerts-worker) | ../monitoring/ecs-alerts | n/a |
+| <a name="module_ecs_log_groups"></a> [ecs\_log\_groups](#module\_ecs\_log\_groups) | terraform-aws-modules/cloudwatch/aws//modules/log-group | ~> 3.0 |
 | <a name="module_efs"></a> [efs](#module\_efs) | cloudposse/efs/aws | n/a |
 | <a name="module_efs_sg"></a> [efs\_sg](#module\_efs\_sg) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_elasticache-alerts"></a> [elasticache-alerts](#module\_elasticache-alerts) | ../monitoring/elasticache-alerts | n/a |

--- a/terraform/modules/ecs/ecs-tasks.tf
+++ b/terraform/modules/ecs/ecs-tasks.tf
@@ -21,8 +21,14 @@ resource "aws_ecs_task_definition" "web" {
   }
 
   container_definitions = templatefile(
-    "${path.module}/task-definitions/web.json.tftpl", local.environment
+    "${path.module}/task-definitions/web.json.tftpl",
+    merge(local.environment,
+      {
+        web_log_group = module.ecs_log_groups["web"].cloudwatch_log_group_name
+      }
+    )
   )
+
 
   volume {
     name = "polytomic"
@@ -60,7 +66,12 @@ resource "aws_ecs_task_definition" "worker" {
   }
 
   container_definitions = templatefile(
-    "${path.module}/task-definitions/worker.json.tftpl", local.environment
+    "${path.module}/task-definitions/worker.json.tftpl",
+    merge(local.environment,
+      {
+        worker_log_group = module.ecs_log_groups["worker"].cloudwatch_log_group_name
+      }
+    )
   )
 
   volume {
@@ -99,7 +110,12 @@ resource "aws_ecs_task_definition" "sync" {
   }
 
   container_definitions = templatefile(
-    "${path.module}/task-definitions/sync.json.tftpl", local.environment
+    "${path.module}/task-definitions/sync.json.tftpl",
+    merge(local.environment,
+      {
+        sync_log_group = module.ecs_log_groups["sync"].cloudwatch_log_group_name
+      }
+    )
   )
 
   volume {
@@ -138,7 +154,12 @@ resource "aws_ecs_task_definition" "scheduler" {
   }
 
   container_definitions = templatefile(
-    "${path.module}/task-definitions/scheduler.json.tftpl", local.environment
+    "${path.module}/task-definitions/scheduler.json.tftpl",
+    merge(local.environment,
+      {
+        scheduler_log_group = module.ecs_log_groups["scheduler"].cloudwatch_log_group_name
+      }
+    )
   )
 
   volume {

--- a/terraform/modules/ecs/logs.tf
+++ b/terraform/modules/ecs/logs.tf
@@ -12,3 +12,22 @@ module "log_group" {
     }
   )
 }
+
+
+module "ecs_log_groups" {
+  source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
+  version = "~> 3.0"
+
+  for_each = toset(["sync", "scheduler", "stats-reporter", "web", "worker"])
+
+  name              = "${var.prefix}-${each.key}-logs"
+  retention_in_days = var.log_retention_days
+
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.prefix}-${each.key}-logs"
+    }
+  )
+}

--- a/terraform/modules/ecs/stats.tf
+++ b/terraform/modules/ecs/stats.tf
@@ -45,8 +45,9 @@ resource "aws_ecs_task_definition" "stats_reporter" {
     "${path.module}/task-definitions/stats-reporter.json.tftpl",
     merge(local.environment,
       {
-        bucket = "${var.prefix}-${var.bucket_prefix}${local.polytomic_stats_bucket}",
-        format = var.stats_format,
+        bucket                   = "${var.prefix}-${var.bucket_prefix}${local.polytomic_stats_bucket}",
+        format                   = var.stats_format,
+        stats_reporter_log_group = module.ecs_log_groups["stats-reporter"].cloudwatch_log_group_name
       }
   ))
 

--- a/terraform/modules/ecs/task-definitions/scheduler.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/scheduler.json.tftpl
@@ -4,10 +4,9 @@
         "logDriver": "awslogs",
         "secretOptions": null,
         "options": {
-            "awslogs-group": "polytomic-scheduler",
+            "awslogs-group": "${scheduler_log_group}",
             "awslogs-region": "${region}",
-            "awslogs-stream-prefix": "service",
-            "awslogs-create-group": "true"
+            "awslogs-stream-prefix": "service"
         }
     },
     %{ else }
@@ -85,10 +84,9 @@
         "logDriver": "awslogs",
         "secretOptions": null,
         "options": {
-            "awslogs-group": "polytomic-scheduler",
+            "awslogs-group": "${scheduler_log_group}",
             "awslogs-region": "${region}",
-            "awslogs-stream-prefix": "service",
-            "awslogs-create-group": "true"
+            "awslogs-stream-prefix": "service"
         }
     },
     "name": "vector",

--- a/terraform/modules/ecs/task-definitions/stats-reporter.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/stats-reporter.json.tftpl
@@ -3,10 +3,9 @@
         "logDriver": "awslogs",
         "secretOptions": null,
         "options": {
-            "awslogs-group": "polytomic-stats-reporter",
+            "awslogs-group": "${stats_reporter_log_group}",
             "awslogs-region": "${region}",
-            "awslogs-stream-prefix": "service",
-            "awslogs-create-group": "true"
+            "awslogs-stream-prefix": "service"
         }
     },
     "environment": [

--- a/terraform/modules/ecs/task-definitions/sync.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/sync.json.tftpl
@@ -4,10 +4,9 @@
         "logDriver": "awslogs",
         "secretOptions": null,
         "options": {
-            "awslogs-group": "polytomic-sync",
+            "awslogs-group": "${sync_log_group}",
             "awslogs-region": "${region}",
-            "awslogs-stream-prefix": "service",
-            "awslogs-create-group": "true"
+            "awslogs-stream-prefix": "service"
         }
     },
     %{ else }
@@ -85,10 +84,9 @@
         "logDriver": "awslogs",
         "secretOptions": null,
         "options": {
-            "awslogs-group": "polytomic-sync",
+            "awslogs-group": "${sync_log_group}",
             "awslogs-region": "${region}",
-            "awslogs-stream-prefix": "service",
-            "awslogs-create-group": "true"
+            "awslogs-stream-prefix": "service"
         }
     },
     "name": "vector",

--- a/terraform/modules/ecs/task-definitions/web.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/web.json.tftpl
@@ -4,10 +4,9 @@
         "logDriver": "awslogs",
         "secretOptions": null,
         "options": {
-            "awslogs-group": "polytomic-web",
+            "awslogs-group": "${web_log_group}",
             "awslogs-region": "${region}",
-            "awslogs-stream-prefix": "service",
-            "awslogs-create-group": "true"
+            "awslogs-stream-prefix": "service"
         }
     },
     %{ else }
@@ -88,10 +87,9 @@
         "logDriver": "awslogs",
         "secretOptions": null,
         "options": {
-            "awslogs-group": "polytomic-web",
+            "awslogs-group": "${web_log_group}",
             "awslogs-region": "${region}",
-            "awslogs-stream-prefix": "service",
-            "awslogs-create-group": "true"
+            "awslogs-stream-prefix": "service"
         }
     },
     "name": "vector",

--- a/terraform/modules/ecs/task-definitions/worker.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/worker.json.tftpl
@@ -4,10 +4,9 @@
         "logDriver": "awslogs",
         "secretOptions": null,
         "options": {
-            "awslogs-group": "polytomic-worker",
+            "awslogs-group": "${worker_log_group}",
             "awslogs-region": "${region}",
-            "awslogs-stream-prefix": "service",
-            "awslogs-create-group": "true"
+            "awslogs-stream-prefix": "service"
         }
     },
     %{ else }
@@ -85,10 +84,9 @@
         "logDriver": "awslogs",
         "secretOptions": null,
         "options": {
-            "awslogs-group": "polytomic-worker",
+            "awslogs-group": "${worker_log_group}",
             "awslogs-region": "${region}",
-            "awslogs-stream-prefix": "service",
-            "awslogs-create-group": "true"
+            "awslogs-stream-prefix": "service"
         }
     },
     "name": "vector",


### PR DESCRIPTION
I've done a bit of testing and the upgrade path for existing users is pretty straightforward. New log groups will be created and the ECS tasks will start using the new ones. Existing log groups will remain since their state is not maintained in terraform. Unfortunately, the existing log groups cannot be imported since log groups cannot be renamed. 

We should consider this a breaking change. I think the only way around importing state would be adding override variables and doing a bit of hacking to get the names to line up with the existing log groups. I think we should leave to bridge alone until we have to cross it.