### PR TITLE
Explicitly allow tagging of ECS resources

### DIFF
--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -191,9 +191,9 @@ module "polytomic-ecs" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.22.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.1.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.27.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Resources
 

--- a/terraform/modules/ecs/iam.tf
+++ b/terraform/modules/ecs/iam.tf
@@ -124,7 +124,7 @@ data "aws_iam_policy_document" "polytomic_stats_reporter" {
 
   statement {
     actions = [
-      "ecs:RunTask"
+      "ecs:RunTask",
       "ecs:TagResource",
     ]
     resources = [

--- a/terraform/modules/ecs/iam.tf
+++ b/terraform/modules/ecs/iam.tf
@@ -31,6 +31,7 @@ data "aws_iam_policy_document" "polytomic_task" {
       "ecs:StartTask",
       "ecs:StopTask",
       "ecs:RunTask",
+      "ecs:TagResource",
       "tag:GetResources",
       "tag:GetTagKeys",
       "tag:GetTagValues",
@@ -124,6 +125,7 @@ data "aws_iam_policy_document" "polytomic_stats_reporter" {
   statement {
     actions = [
       "ecs:RunTask"
+      "ecs:TagResource",
     ]
     resources = [
       "${aws_ecs_task_definition.stats_reporter[0].arn}"


### PR DESCRIPTION
This permission will be required for tagging ECS resources beginnning 29 March 2024.