### PR TITLE
Refactoring ecs module to improve security posture with secrets

### DIFF
--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -185,15 +185,17 @@ module "polytomic-ecs" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.27.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Resources
 
@@ -220,6 +222,8 @@ module "polytomic-ecs" {
 | [aws_iam_role_policy.polytomic_ecs_task_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.polytomic_stats_reporter_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_kms_key.alerts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_secretsmanager_secret.task_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.task_secrets_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_sns_topic.alerts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic_policy.oom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
 | [aws_sns_topic_subscription.alert_emails](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
@@ -297,6 +301,7 @@ module "polytomic-ecs" {
 | <a name="input_enable_monitoring"></a> [enable\_monitoring](#input\_enable\_monitoring) | enable automatic monitoring | `bool` | `false` | no |
 | <a name="input_enable_stats"></a> [enable\_stats](#input\_enable\_stats) | enable automatic stats reporting | `bool` | `false` | no |
 | <a name="input_extra_environment"></a> [extra\_environment](#input\_extra\_environment) | Extra environment variables to pass to the containers | `map(string)` | `{}` | no |
+| <a name="input_extra_secrets"></a> [extra\_secrets](#input\_extra\_secrets) | Extra secrets that make it into the managed aws secret manager that get passed to the containers securely | `map(string)` | `{}` | no |
 | <a name="input_load_balancer_internal"></a> [load\_balancer\_internal](#input\_load\_balancer\_internal) | use internal load balancer | `bool` | `false` | no |
 | <a name="input_load_balancer_redirect_https"></a> [load\_balancer\_redirect\_https](#input\_load\_balancer\_redirect\_https) | enable https listener on load balancer | `bool` | `false` | no |
 | <a name="input_load_balancer_security_groups"></a> [load\_balancer\_security\_groups](#input\_load\_balancer\_security\_groups) | security groups for load balancer | `list(string)` | `[]` | no |

--- a/terraform/modules/ecs/ecs-tasks.tf
+++ b/terraform/modules/ecs/ecs-tasks.tf
@@ -25,7 +25,6 @@ resource "aws_ecs_task_definition" "web" {
     merge(local.environment,
       {
         web_log_group = module.ecs_log_groups["web"].cloudwatch_log_group_name
-        # task_secret_arn = aws_secretsmanager_secret.task_secrets.arn
       }
     )
   )

--- a/terraform/modules/ecs/ecs-tasks.tf
+++ b/terraform/modules/ecs/ecs-tasks.tf
@@ -25,6 +25,7 @@ resource "aws_ecs_task_definition" "web" {
     merge(local.environment,
       {
         web_log_group = module.ecs_log_groups["web"].cloudwatch_log_group_name
+        # task_secret_arn = aws_secretsmanager_secret.task_secrets.arn
       }
     )
   )

--- a/terraform/modules/ecs/iam.tf
+++ b/terraform/modules/ecs/iam.tf
@@ -100,6 +100,13 @@ data "aws_iam_policy_document" "polytomic_execution" {
 
     resources = ["*"]
   }
+
+  statement {
+    sid = "PolytomicAccessSecrets"
+
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [aws_secretsmanager_secret.task_secrets.arn]
+  }
 }
 
 resource "aws_iam_role" "polytomic_ecs_execution_role" {

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -40,11 +40,8 @@ locals {
   standard_env_vars = {
     AWS_REGION                          = var.region,
     CAPTURE_SYNC_LOGS                   = var.polytomic_sync_logging_enabled
-    DATABASE_URL                        = local.database_url,
     DEFAULT_OPERATIONAL_BUCKET          = "s3://${var.prefix}-${var.bucket_prefix}${local.polytomic_execution_bucket}?region=${var.region}"
     DEPLOYMENT                          = var.polytomic_deployment,
-    DEPLOYMENT_API_KEY                  = var.polytomic_deployment_api_key == "" ? random_password.deployment_api_key[0].result : var.polytomic_deployment_api_key,
-    DEPLOYMENT_KEY                      = var.polytomic_deployment_key,
     DEPLOYMENT_LINKS                    = local.links,
     ENABLED_BACKENDS                    = join(",", var.polytomic_enabled_backends)
     ENV                                 = var.polytomic_deployment
@@ -57,7 +54,6 @@ locals {
     FARGATE_EXECUTOR_SUBNETS            = join(",", var.vpc_id == "" ? module.vpc[0].private_subnets : var.private_subnet_ids),
     GA_MEASUREMENT_ID                   = var.polytomic_ga_measurement_id,
     GOOGLE_CLIENT_ID                    = var.polytomic_google_client_id,
-    GOOGLE_CLIENT_SECRET                = var.polytomic_google_client_secret,
     JOB_PAYLOAD_PATH                    = "${var.polytomic_data_path}/jobs",
     LEGACY_CONFIG                       = var.polytomic_legacy_config
     LOCAL_DATA                          = var.polytomic_data_path != "",
@@ -82,7 +78,6 @@ locals {
     TASK_EXECUTOR_MEMORY_RESERVATION    = var.polytomic_resource_sync_memory,
     TASK_EXECUTOR_TAGS                  = local.tags
     TX_BUFFER_SIZE                      = var.polytomic_tx_buffer_size
-    WORKOS_API_KEY                      = var.polytomic_workos_api_key,
     WORKOS_CLIENT_ID                    = var.polytomic_workos_client_id,
 
     POLYTOMIC_DD_AGENT       = var.polytomic_use_dd_agent,
@@ -109,7 +104,17 @@ locals {
     polytomic_dd_agent       = var.polytomic_use_dd_agent,
     polytomic_dd_agent_image = var.polytomic_dd_agent_image,
 
-    env = merge(local.standard_env_vars, var.extra_environment)
+    env             = merge(local.standard_env_vars, var.extra_environment)
+    secrets         = merge(local.standard_secrets, var.extra_secrets)
+    task_secret_arn = aws_secretsmanager_secret.task_secrets.arn
+  }
+
+  standard_secrets = {
+    DATABASE_URL         = local.database_url,
+    DEPLOYMENT_API_KEY   = var.polytomic_deployment_api_key == "" ? random_password.deployment_api_key[0].result : var.polytomic_deployment_api_key,
+    DEPLOYMENT_KEY       = var.polytomic_deployment_key,
+    GOOGLE_CLIENT_SECRET = var.polytomic_google_client_secret,
+    WORKOS_API_KEY       = var.polytomic_workos_api_key,
   }
 
 }

--- a/terraform/modules/ecs/outputs.tf
+++ b/terraform/modules/ecs/outputs.tf
@@ -15,7 +15,8 @@ output "target_group_arn" {
 }
 
 output "deploy_api_key" {
-  value       = local.environment.env.DEPLOYMENT_API_KEY
+  value       = local.standard_secrets.DEPLOYMENT_API_KEY
+  sensitive   = true
   description = "API key used to authenticate with the Polytomic management API."
 }
 

--- a/terraform/modules/ecs/secrets.tf
+++ b/terraform/modules/ecs/secrets.tf
@@ -1,0 +1,10 @@
+resource "aws_secretsmanager_secret" "task_secrets" {
+  name_prefix             = "${var.prefix}-ecs-task-secrets-"
+  description             = "managed via terraform"
+  recovery_window_in_days = 7
+}
+
+resource "aws_secretsmanager_secret_version" "task_secrets_version" {
+  secret_id     = aws_secretsmanager_secret.task_secrets.id
+  secret_string = jsonencode(merge(local.standard_secrets, var.extra_secrets))
+}

--- a/terraform/modules/ecs/task-definitions/scheduler.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/scheduler.json.tftpl
@@ -47,6 +47,14 @@
             "value": "scheduler"
         }
     ],
+    "secrets": [
+        %{ for key in secrets ~}
+        {
+            "name": "${key}",
+            "valueFrom": "${task_secret_arn}:${key}::"
+        }%{ if key != keys(secrets)[length(secrets)-1] ~},%{ endif ~}
+        %{ endfor ~}
+    ],
     "mountPoints": [
     {
         "containerPath": "${mount_path}",

--- a/terraform/modules/ecs/task-definitions/scheduler.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/scheduler.json.tftpl
@@ -48,12 +48,12 @@
         }
     ],
     "secrets": [
-        %{ for key in secrets ~}
+%{ for key, _ in secrets ~}
         {
             "name": "${key}",
             "valueFrom": "${task_secret_arn}:${key}::"
-        }%{ if key != keys(secrets)[length(secrets)-1] ~},%{ endif ~}
-        %{ endfor ~}
+        }%{ if key != keys(secrets)[length(keys(secrets)) - 1] },%{ endif }
+%{ endfor ~}
     ],
     "mountPoints": [
     {

--- a/terraform/modules/ecs/task-definitions/stats-reporter.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/stats-reporter.json.tftpl
@@ -20,6 +20,14 @@
             "value": "stats"
         }
     ],
+    "secrets": [
+        %{ for key in secrets ~}
+        {
+            "name": "${key}",
+            "valueFrom": "${task_secret_arn}:${key}::"
+        }%{ if key != keys(secrets)[length(secrets)-1] ~},%{ endif ~}
+        %{ endfor ~}
+    ],
     "memoryReservation": 2048,
     "image": "${image}",
     "name": "stats",

--- a/terraform/modules/ecs/task-definitions/stats-reporter.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/stats-reporter.json.tftpl
@@ -21,12 +21,12 @@
         }
     ],
     "secrets": [
-        %{ for key in secrets ~}
+%{ for key, _ in secrets ~}
         {
             "name": "${key}",
             "valueFrom": "${task_secret_arn}:${key}::"
-        }%{ if key != keys(secrets)[length(secrets)-1] ~},%{ endif ~}
-        %{ endfor ~}
+        }%{ if key != keys(secrets)[length(keys(secrets)) - 1] },%{ endif }
+%{ endfor ~}
     ],
     "memoryReservation": 2048,
     "image": "${image}",

--- a/terraform/modules/ecs/task-definitions/sync.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/sync.json.tftpl
@@ -47,6 +47,14 @@
             "value": "sync"
         }
     ],
+    "secrets": [
+        %{ for key in secrets ~}
+        {
+            "name": "${key}",
+            "valueFrom": "${task_secret_arn}:${key}::"
+        }%{ if key != keys(secrets)[length(secrets)-1] ~},%{ endif ~}
+        %{ endfor ~}
+    ],
     "mountPoints": [
     {
         "containerPath": "${mount_path}",

--- a/terraform/modules/ecs/task-definitions/sync.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/sync.json.tftpl
@@ -48,12 +48,12 @@
         }
     ],
     "secrets": [
-        %{ for key in secrets ~}
+%{ for key, _ in secrets ~}
         {
             "name": "${key}",
             "valueFrom": "${task_secret_arn}:${key}::"
-        }%{ if key != keys(secrets)[length(secrets)-1] ~},%{ endif ~}
-        %{ endfor ~}
+        }%{ if key != keys(secrets)[length(keys(secrets)) - 1] },%{ endif }
+%{ endfor ~}
     ],
     "mountPoints": [
     {

--- a/terraform/modules/ecs/task-definitions/web.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/web.json.tftpl
@@ -62,6 +62,14 @@
             "value": "${polytomic_port}"
         }
     ],
+    "secrets": [
+        %{ for key in secrets ~}
+        {
+            "name": "${key}",
+            "valueFrom": "${task_secret_arn}:${key}::"
+        }%{ if key != keys(secrets)[length(secrets)-1] ~},%{ endif ~}
+        %{ endfor ~}
+    ],
     "mountPoints": [
     {
         "containerPath": "${mount_path}",

--- a/terraform/modules/ecs/task-definitions/web.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/web.json.tftpl
@@ -63,12 +63,12 @@
         }
     ],
     "secrets": [
-        %{ for key in secrets ~}
+%{ for key, _ in secrets ~}
         {
             "name": "${key}",
             "valueFrom": "${task_secret_arn}:${key}::"
-        }%{ if key != keys(secrets)[length(secrets)-1] ~},%{ endif ~}
-        %{ endfor ~}
+        }%{ if key != keys(secrets)[length(keys(secrets)) - 1] },%{ endif }
+%{ endfor ~}
     ],
     "mountPoints": [
     {

--- a/terraform/modules/ecs/task-definitions/worker.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/worker.json.tftpl
@@ -47,6 +47,14 @@
             "value": "worker,schemacache"
         }
     ],
+    "secrets": [
+        %{ for key in secrets ~}
+        {
+            "name": "${key}",
+            "valueFrom": "${task_secret_arn}:${key}::"
+        }%{ if key != keys(secrets)[length(secrets)-1] ~},%{ endif ~}
+        %{ endfor ~}
+    ],
     "mountPoints": [
     {
         "containerPath": "${mount_path}",

--- a/terraform/modules/ecs/task-definitions/worker.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/worker.json.tftpl
@@ -48,12 +48,12 @@
         }
     ],
     "secrets": [
-        %{ for key in secrets ~}
+%{ for key, _ in secrets ~}
         {
             "name": "${key}",
             "valueFrom": "${task_secret_arn}:${key}::"
-        }%{ if key != keys(secrets)[length(secrets)-1] ~},%{ endif ~}
-        %{ endfor ~}
+        }%{ if key != keys(secrets)[length(keys(secrets)) - 1] },%{ endif }
+%{ endfor ~}
     ],
     "mountPoints": [
     {

--- a/terraform/modules/ecs/vars.tf
+++ b/terraform/modules/ecs/vars.tf
@@ -537,6 +537,12 @@ variable "extra_environment" {
   default     = {}
 }
 
+variable "extra_secrets" {
+  description = "Extra secrets that make it into the managed aws secret manager that get passed to the containers securely"
+  type        = map(string)
+  sensitive   = true
+  default     = {}
+}
 
 variable "load_balancer_redirect_https" {
   description = "enable https listener on load balancer"

--- a/terraform/modules/ecs/versions.tf
+++ b/terraform/modules/ecs/versions.tf
@@ -4,7 +4,17 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.6"
+      version = ">= 4.0"
+    }
+
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
     }
   }
 }


### PR DESCRIPTION
This PR aims to improve the security posture around sensitive values passed into the ecs module. Currently all sensitive/secret values are written in the plain directly into the ecs task definition. With these changes, all sensitive values are written to an aws secret manager secret that this module will manage. Then the ecs task definitions references those secrets to pass them in as environment variables to the containers. The user of the module can add additional secrets as well via the new var `extra_secrets`. The screenshots below illustrate this best

This is a new aws secret resource that this module now manages:
![aws_secret](https://github.com/user-attachments/assets/76d9dfa0-f0cc-44a3-86f4-4cceb7e6e6a0)

The ECS task definitions no longer pass sensitive values in the plain, instead they are passed securely via the `secrets` object:
![ecs_secrets](https://github.com/user-attachments/assets/1f37ebeb-c5e0-4ab7-91ed-4a0e3f6b426e)
