### PR TITLE
Remove container memory reservations

### DIFF
--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -193,9 +193,9 @@ module "polytomic-ecs" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.27.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Resources
 

--- a/terraform/modules/ecs/ecs-tasks.tf
+++ b/terraform/modules/ecs/ecs-tasks.tf
@@ -40,7 +40,6 @@ resource "aws_ecs_task_definition" "web" {
       transit_encryption_port = 2999
     }
   }
-
 }
 
 resource "aws_ecs_task_definition" "worker" {
@@ -84,7 +83,6 @@ resource "aws_ecs_task_definition" "worker" {
       transit_encryption_port = 2999
     }
   }
-
 }
 
 resource "aws_ecs_task_definition" "sync" {
@@ -132,7 +130,6 @@ resource "aws_ecs_task_definition" "sync" {
       transit_encryption_port = 2999
     }
   }
-
 }
 
 resource "aws_ecs_task_definition" "scheduler" {
@@ -176,7 +173,6 @@ resource "aws_ecs_task_definition" "scheduler" {
       transit_encryption_port = 2999
     }
   }
-
 }
 
 resource "aws_ecs_service" "web" {

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -116,5 +116,4 @@ locals {
     GOOGLE_CLIENT_SECRET = var.polytomic_google_client_secret,
     WORKOS_API_KEY       = var.polytomic_workos_api_key,
   }
-
 }

--- a/terraform/modules/ecs/task-definitions/scheduler.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/scheduler.json.tftpl
@@ -60,7 +60,6 @@
         "containerPath": "${mount_path}",
         "sourceVolume": "polytomic"
     }],
-    "memoryReservation": ${scheduler_memory},
     "image": "${image}",
     "portMappings": [
         {

--- a/terraform/modules/ecs/task-definitions/sync.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/sync.json.tftpl
@@ -60,7 +60,6 @@
         "containerPath": "${mount_path}",
         "sourceVolume": "polytomic"
     }],
-    "memoryReservation": ${sync_memory},
     "image": "${image}",
     "portMappings": [
         {

--- a/terraform/modules/ecs/task-definitions/web.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/web.json.tftpl
@@ -75,7 +75,6 @@
         "containerPath": "${mount_path}",
         "sourceVolume": "polytomic"
     }],
-    "memoryReservation": ${web_memory},
     "image": "${image}",
     "privileged": false,
     "name": "web"

--- a/terraform/modules/ecs/task-definitions/worker.json.tftpl
+++ b/terraform/modules/ecs/task-definitions/worker.json.tftpl
@@ -60,7 +60,6 @@
         "containerPath": "${mount_path}",
         "sourceVolume": "polytomic"
     }],
-    "memoryReservation": ${worker_memory},
     "image": "${image}",
     "portMappings": [
         {


### PR DESCRIPTION
These are the same as the task reservations; specifying them here makes it challenging to override the task memory limits.