### PR TITLE
feat: Add `attach_deny_insecure_transport_policy` option to S3 module

### DIFF
--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -193,9 +193,9 @@ module "polytomic-ecs" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.27.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Resources
 
@@ -271,6 +271,7 @@ module "polytomic-ecs" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_ecs_security_groups"></a> [additional\_ecs\_security\_groups](#input\_additional\_ecs\_security\_groups) | ECS security group ids | `list` | `[]` | no |
 | <a name="input_alert_emails"></a> [alert\_emails](#input\_alert\_emails) | Email addresses to send alerts to | `list(string)` | `[]` | no |
+| <a name="input_attach_deny_insecure_transport_policy"></a> [attach\_deny\_insecure\_transport\_policy](#input\_attach\_deny\_insecure\_transport\_policy) | Attach a deny insecure transport policy to the S3 buckets | `bool` | `false` | no |
 | <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS profile to use | `string` | `"default"` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Bucket prefix | `string` | `""` | no |
 | <a name="input_database_allocated_storage"></a> [database\_allocated\_storage](#input\_database\_allocated\_storage) | Database allocated storage | `number` | `20` | no |

--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -193,9 +193,9 @@ module "polytomic-ecs" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.27.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Resources
 

--- a/terraform/modules/ecs/buckets.tf
+++ b/terraform/modules/ecs/buckets.tf
@@ -10,10 +10,11 @@ module "s3_bucket" {
   bucket = "${var.prefix}-${var.bucket_prefix}${each.key}"
   acl    = "private"
 
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
+  block_public_acls                     = true
+  block_public_policy                   = true
+  ignore_public_acls                    = true
+  restrict_public_buckets               = true
+  attach_deny_insecure_transport_policy = var.attach_deny_insecure_transport_policy
 
   control_object_ownership = true
   object_ownership         = "BucketOwnerPreferred"

--- a/terraform/modules/ecs/vars.tf
+++ b/terraform/modules/ecs/vars.tf
@@ -492,6 +492,12 @@ variable "tags" {
 }
 
 
+variable "attach_deny_insecure_transport_policy" {
+  type        = bool
+  description = "Attach a deny insecure transport policy to the S3 buckets"
+  default     = false
+}
+
 variable "bucket_prefix" {
   description = "Bucket prefix"
   default     = ""


### PR DESCRIPTION
- Introduce new variable `attach_deny_insecure_transport_policy` (default: false)
- Allows users to attach a deny-insecure-transport policy to the S3 bucket
- Improves security configurations by restricting HTTP traffic where desired