### PR TITLE
Add opt-in Cluster Autoscaler to eks-addons module

### DIFF
--- a/terraform/modules/eks-addons/main.tf
+++ b/terraform/modules/eks-addons/main.tf
@@ -67,6 +67,57 @@ resource "helm_release" "lb" {
   ]
 }
 
+# Cluster Autoscaler
+# Watches for unschedulable pods and adjusts the ASG desired capacity
+# so the node group scales up (within max_size) automatically.
+module "cluster_autoscaler_role" {
+  count   = var.enable_cluster_autoscaler ? 1 : 0
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.0"
+
+  name                                 = "${var.prefix}_cluster_autoscaler"
+  attach_cluster_autoscaler_policy     = true
+  cluster_autoscaler_cluster_names     = [var.cluster_name]
+
+  oidc_providers = {
+    main = {
+      provider_arn               = var.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:cluster-autoscaler"]
+    }
+  }
+}
+
+resource "helm_release" "cluster_autoscaler" {
+  count      = var.enable_cluster_autoscaler ? 1 : 0
+  name       = "cluster-autoscaler"
+  repository = "https://kubernetes.github.io/autoscaler"
+  chart      = "cluster-autoscaler"
+  namespace  = "kube-system"
+
+  set = [
+    {
+      name  = "autoDiscovery.clusterName"
+      value = var.cluster_name
+    },
+    {
+      name  = "awsRegion"
+      value = var.region
+    },
+    {
+      name  = "rbac.serviceAccount.create"
+      value = "true"
+    },
+    {
+      name  = "rbac.serviceAccount.name"
+      value = "cluster-autoscaler"
+    },
+    {
+      name  = "rbac.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+      value = module.cluster_autoscaler_role[0].arn
+    },
+  ]
+}
+
 # Polytomic application IAM role
 module "polytomic_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"

--- a/terraform/modules/eks-addons/vars.tf
+++ b/terraform/modules/eks-addons/vars.tf
@@ -22,3 +22,9 @@ variable "cluster_name" {
 variable "oidc_provider_arn" {
   description = "OIDC provider ARN"
 }
+
+variable "enable_cluster_autoscaler" {
+  description = "Deploy the Kubernetes Cluster Autoscaler for automatic node scaling"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
The EKS module sets ASG min/max/desired but nothing watches for unschedulable pods to trigger scale-up. This adds an IRSA role and Helm release for the Kubernetes Cluster Autoscaler, gated behind enable_cluster_autoscaler (default false) so existing deployments are unaffected.