### PR TITLE
ECS module: share one image tag across the three sidecar URIs

### DIFF
--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -193,9 +193,9 @@ module "polytomic-ecs" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.27.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0, < 6.0.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Resources
 
@@ -316,7 +316,7 @@ module "polytomic-ecs" {
 | <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | Cloudwatch log retention days | `number` | `120` | no |
 | <a name="input_polytomic_bootstrap"></a> [polytomic\_bootstrap](#input\_polytomic\_bootstrap) | Whether to bootstrap Polytomic | `bool` | `false` | no |
 | <a name="input_polytomic_data_path"></a> [polytomic\_data\_path](#input\_polytomic\_data\_path) | Filesystem path to local data cache | `string` | `"/var/polytomic"` | no |
-| <a name="input_polytomic_dd_agent_image"></a> [polytomic\_dd\_agent\_image](#input\_polytomic\_dd\_agent\_image) | Docker image to use for the Datadog agent | `string` | `"568237466542.dkr.ecr.us-west-2.amazonaws.com/polytomic-dd-agent:latest"` | no |
+| <a name="input_polytomic_dd_agent_image"></a> [polytomic\_dd\_agent\_image](#input\_polytomic\_dd\_agent\_image) | Override URI for the Datadog agent sidecar container. Defaults to <polytomic\_image\_registry>/polytomic-dd-agent:<polytomic\_image\_tag>. | `string` | `""` | no |
 | <a name="input_polytomic_deployment"></a> [polytomic\_deployment](#input\_polytomic\_deployment) | A unique identifier for your on premises deploy, provided by Polytomic | `string` | `""` | no |
 | <a name="input_polytomic_deployment_api_key"></a> [polytomic\_deployment\_api\_key](#input\_polytomic\_deployment\_api\_key) | API key used to authenticate with the Polytomic management API | `string` | `""` | no |
 | <a name="input_polytomic_deployment_key"></a> [polytomic\_deployment\_key](#input\_polytomic\_deployment\_key) | The license key for your deployment, provided by Polytomic | `string` | `""` | no |
@@ -325,10 +325,12 @@ module "polytomic-ecs" {
 | <a name="input_polytomic_ga_measurement_id"></a> [polytomic\_ga\_measurement\_id](#input\_polytomic\_ga\_measurement\_id) | Google Analytics Measurement ID | `string` | `""` | no |
 | <a name="input_polytomic_google_client_id"></a> [polytomic\_google\_client\_id](#input\_polytomic\_google\_client\_id) | Google OAuth Client ID, obtained by creating a OAuth 2.0 Client ID | `string` | `""` | no |
 | <a name="input_polytomic_google_client_secret"></a> [polytomic\_google\_client\_secret](#input\_polytomic\_google\_client\_secret) | Google OAuth Client Secret, obtained by creating a OAuth 2.0 Client ID | `string` | `""` | no |
-| <a name="input_polytomic_image"></a> [polytomic\_image](#input\_polytomic\_image) | Docker image to use for the Polytomic ECS cluster | `string` | `"568237466542.dkr.ecr.us-west-2.amazonaws.com/polytomic-onprem:latest"` | no |
+| <a name="input_polytomic_image"></a> [polytomic\_image](#input\_polytomic\_image) | Override URI for the Polytomic app container. Defaults to <polytomic\_image\_registry>/polytomic-onprem:<polytomic\_image\_tag>. | `string` | `""` | no |
+| <a name="input_polytomic_image_registry"></a> [polytomic\_image\_registry](#input\_polytomic\_image\_registry) | Container registry that hosts the Polytomic images. Combined with polytomic\_image\_tag to compose the default image URIs for the app, logger (Vector), and Datadog agent containers. Override the individual *\_image variables to opt out of this composition. | `string` | `"568237466542.dkr.ecr.us-west-2.amazonaws.com"` | no |
+| <a name="input_polytomic_image_tag"></a> [polytomic\_image\_tag](#input\_polytomic\_image\_tag) | Tag applied to the Polytomic app, logger, and Datadog agent images. A single release tag (e.g. "rel2026.05.15") moves all three containers together; override individual *\_image variables for fine-grained control. | `string` | `"latest"` | no |
 | <a name="input_polytomic_legacy_config"></a> [polytomic\_legacy\_config](#input\_polytomic\_legacy\_config) | Use legacy configuration | `bool` | `false` | no |
 | <a name="input_polytomic_log_level"></a> [polytomic\_log\_level](#input\_polytomic\_log\_level) | The log level to use for Polytomic | `string` | `"info"` | no |
-| <a name="input_polytomic_logger_image"></a> [polytomic\_logger\_image](#input\_polytomic\_logger\_image) | Docker image to use for the Polytomic log aggregator | `string` | `"568237466542.dkr.ecr.us-west-2.amazonaws.com/polytomic-vector:latest"` | no |
+| <a name="input_polytomic_logger_image"></a> [polytomic\_logger\_image](#input\_polytomic\_logger\_image) | Override URI for the Polytomic Vector (log aggregator) sidecar container. Defaults to <polytomic\_image\_registry>/polytomic-vector:<polytomic\_image\_tag>. | `string` | `""` | no |
 | <a name="input_polytomic_managed_logs"></a> [polytomic\_managed\_logs](#input\_polytomic\_managed\_logs) | Use managed logs | `bool` | `false` | no |
 | <a name="input_polytomic_mcp_api_version"></a> [polytomic\_mcp\_api\_version](#input\_polytomic\_mcp\_api\_version) | Polytomic API version for the MCP server | `string` | `"2025-09-18"` | no |
 | <a name="input_polytomic_mcp_enabled"></a> [polytomic\_mcp\_enabled](#input\_polytomic\_mcp\_enabled) | Enable the MCP server service | `bool` | `false` | no |

--- a/terraform/modules/ecs/ecs-tasks.tf
+++ b/terraform/modules/ecs/ecs-tasks.tf
@@ -441,9 +441,9 @@ resource "aws_ecs_task_definition" "mcp" {
       polytomic_url             = var.polytomic_url == "" ? "http://${aws_alb.main.dns_name}/" : local.parsed_polytomic_url.scheme == null ? "https://${var.polytomic_url}" : var.polytomic_url
       polytomic_mcp_api_version = var.polytomic_mcp_api_version
       polytomic_logger          = var.polytomic_use_logger
-      polytomic_logger_image    = var.polytomic_logger_image
+      polytomic_logger_image    = local.polytomic_logger_image
       polytomic_dd_agent        = var.polytomic_use_dd_agent
-      polytomic_dd_agent_image  = var.polytomic_dd_agent_image
+      polytomic_dd_agent_image  = local.polytomic_dd_agent_image
       support_secrets           = local.environment.support_secrets
       task_secret_arn           = local.environment.task_secret_arn
     }

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -34,6 +34,13 @@ locals {
   alert_emails               = var.alert_emails == [] ? [local.monitoring_email] : concat(var.alert_emails, [local.monitoring_email])
   parsed_polytomic_url       = regex("(?:(?P<scheme>[^:/?#]+):)?(?://(?P<authority>[^/?#]*))?(?P<path>[^?#]*)(?:\\?(?P<query>[^#]*))?(?:#(?P<fragment>.*))?", var.polytomic_url)
 
+  # Image URIs. Each var.polytomic_*_image acts as an opt-out override; when
+  # unset the registry+tag pair composes the default. A single release tag
+  # (var.polytomic_image_tag) moves all three containers together, matching
+  # how the release pipeline (release-onprem.yml) tags everything at once.
+  polytomic_image          = var.polytomic_image != "" ? var.polytomic_image : "${var.polytomic_image_registry}/polytomic-onprem:${var.polytomic_image_tag}"
+  polytomic_logger_image   = var.polytomic_logger_image != "" ? var.polytomic_logger_image : "${var.polytomic_image_registry}/polytomic-vector:${var.polytomic_image_tag}"
+  polytomic_dd_agent_image = var.polytomic_dd_agent_image != "" ? var.polytomic_dd_agent_image : "${var.polytomic_image_registry}/polytomic-dd-agent:${var.polytomic_image_tag}"
 
   standard_env_vars = {
     AWS_REGION                          = var.region,
@@ -82,9 +89,9 @@ locals {
     WORKOS_CLIENT_ID                    = var.polytomic_workos_client_id,
 
     POLYTOMIC_DD_AGENT       = var.polytomic_use_dd_agent,
-    POLYTOMIC_DD_AGENT_IMAGE = var.polytomic_dd_agent_image
+    POLYTOMIC_DD_AGENT_IMAGE = local.polytomic_dd_agent_image
     POLYTOMIC_LOGGER         = var.polytomic_use_logger,
-    POLYTOMIC_LOGGER_IMAGE   = var.polytomic_logger_image,
+    POLYTOMIC_LOGGER_IMAGE   = local.polytomic_logger_image,
 
     RUST_BACKTRACE = 1
   }
@@ -96,15 +103,15 @@ locals {
     scheduler_memory       = var.polytomic_resource_scheduler_memory
     schemacache_memory     = var.polytomic_resource_schemacache_memory
     ingest_memory          = var.polytomic_resource_ingest_memory
-    image                  = var.polytomic_image,
+    image                  = local.polytomic_image,
     region                 = var.region,
     polytomic_port         = var.polytomic_port,
     mount_path             = var.polytomic_data_path,
     polytomic_logger       = var.polytomic_use_logger
-    polytomic_logger_image = var.polytomic_logger_image,
+    polytomic_logger_image = local.polytomic_logger_image,
 
     polytomic_dd_agent       = var.polytomic_use_dd_agent,
-    polytomic_dd_agent_image = var.polytomic_dd_agent_image,
+    polytomic_dd_agent_image = local.polytomic_dd_agent_image,
 
     env     = merge(local.standard_env_vars, var.extra_environment)
     secrets = merge(local.deployment_secrets, local.standard_secrets, var.extra_secrets)

--- a/terraform/modules/ecs/vars.tf
+++ b/terraform/modules/ecs/vars.tf
@@ -10,9 +10,19 @@ variable "aws_profile" {
   description = "AWS profile to use"
 }
 
+variable "polytomic_image_registry" {
+  default     = "568237466542.dkr.ecr.us-west-2.amazonaws.com"
+  description = "Container registry that hosts the Polytomic images. Combined with polytomic_image_tag to compose the default image URIs for the app, logger (Vector), and Datadog agent containers. Override the individual *_image variables to opt out of this composition."
+}
+
+variable "polytomic_image_tag" {
+  default     = "latest"
+  description = "Tag applied to the Polytomic app, logger, and Datadog agent images. A single release tag (e.g. \"rel2026.05.15\") moves all three containers together; override individual *_image variables for fine-grained control."
+}
+
 variable "polytomic_image" {
-  default     = "568237466542.dkr.ecr.us-west-2.amazonaws.com/polytomic-onprem:latest"
-  description = "Docker image to use for the Polytomic ECS cluster"
+  default     = ""
+  description = "Override URI for the Polytomic app container. Defaults to <polytomic_image_registry>/polytomic-onprem:<polytomic_image_tag>."
 }
 
 variable "polytomic_single_player" {
@@ -208,8 +218,8 @@ variable "polytomic_use_logger" {
 }
 
 variable "polytomic_logger_image" {
-  description = "Docker image to use for the Polytomic log aggregator"
-  default     = "568237466542.dkr.ecr.us-west-2.amazonaws.com/polytomic-vector:latest"
+  description = "Override URI for the Polytomic Vector (log aggregator) sidecar container. Defaults to <polytomic_image_registry>/polytomic-vector:<polytomic_image_tag>."
+  default     = ""
 }
 
 variable "polytomic_use_dd_agent" {
@@ -218,8 +228,8 @@ variable "polytomic_use_dd_agent" {
 }
 
 variable "polytomic_dd_agent_image" {
-  description = "Docker image to use for the Datadog agent"
-  default     = "568237466542.dkr.ecr.us-west-2.amazonaws.com/polytomic-dd-agent:latest"
+  description = "Override URI for the Datadog agent sidecar container. Defaults to <polytomic_image_registry>/polytomic-dd-agent:<polytomic_image_tag>."
+  default     = ""
 }
 
 variable "polytomic_mcp_enabled" {

--- a/terraform/modules/eks-helm/README.md
+++ b/terraform/modules/eks-helm/README.md
@@ -9,8 +9,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.42.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 3.1.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.0 |
 
 ## Modules
 

--- a/terraform/modules/gke-helm/README.md
+++ b/terraform/modules/gke-helm/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 3.1.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.0 |
 
 ## Modules
 
@@ -73,9 +73,4 @@ No modules.
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_chart_version"></a> [chart\_version](#output\_chart\_version) | Deployed Helm chart version |
-| <a name="output_release_name"></a> [release\_name](#output\_release\_name) | Helm release name |
-| <a name="output_release_namespace"></a> [release\_namespace](#output\_release\_namespace) | Kubernetes namespace for the Helm release |
-| <a name="output_url"></a> [url](#output\_url) | Full Polytomic URL |
+No outputs.

--- a/terraform/modules/gke/README.md
+++ b/terraform/modules/gke/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 6.50.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0, < 8.0.0 |
 
 ## Modules
 


### PR DESCRIPTION
The ECS module had three independent full-URI image variables, each defaulting to .../polytomic-{onprem,vector,dd-agent}:latest. Customers were expected to update them in lockstep on every release — the release pipeline already builds and tags all three together — but the variable shape didn't encode that intent, and the staging workflow currently bumps only polytomic_image while polytomic_logger_image and polytomic_dd_agent_image silently fall back to :latest. That makes "pin the whole release" a four-line variable block instead of one.

Add polytomic_image_tag (default "latest") and polytomic_image_registry (default our ECR) variables. Compose the three image URIs in locals, keyed off the tag/registry pair. The existing polytomic_image, polytomic_logger_image, and polytomic_dd_agent_image variables remain as opt-out overrides — set them to a fully qualified URI to bypass composition (e.g. for a customer mirroring to a different registry). Default behavior is unchanged: empty overrides + latest tag produces the same URIs as before.