### PR TITLE
Move terraform module tags to slash-free format

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,7 +1,5 @@
 # Versioning and Release Strategy
 
-**Adopted**: January 20, 2026
-
 This repository uses component-specific tags for releases. Each Terraform module and the Helm chart are versioned independently.
 
 ## Tag Format
@@ -10,24 +8,50 @@ This repository uses component-specific tags for releases. Each Terraform module
 Tags follow the pattern: `polytomic-<version>` (required by chart-releaser)
 
 **Terraform Modules:**
-Tags follow the pattern: `terraform/<module>/v<version>`
+Tags follow the pattern: `<module>-v<version>`
 
 **Examples:**
 ```
 polytomic-1.0.2
-terraform/ecs/v2.7.0
-terraform/eks/v1.0.0
-terraform/gke/v1.0.0
+ecs-v2.9.0
+eks-v1.2.0
+gke-v1.3.0
 ```
 
 **Component prefixes:**
 - `polytomic-` - Helm chart (no v prefix)
-- `terraform/ecs/` - ECS module
-- `terraform/eks/` - EKS module
-- `terraform/eks-addons/` - EKS addons module
-- `terraform/eks-helm/` - EKS Helm deployment module
-- `terraform/gke/` - GKE module
-- `terraform/gke-helm/` - GKE Helm deployment module
+- `ecs-v` - ECS module
+- `eks-v` - EKS module
+- `eks-addons-v` - EKS addons module
+- `eks-helm-v` - EKS Helm deployment module
+- `gke-v` - GKE module
+- `gke-helm-v` - GKE Helm deployment module
+
+### Legacy tag format
+
+Terraform module tags created before this change used a slash-separated path:
+
+```
+terraform/<module>/v<version>
+```
+
+For example: `terraform/ecs/v2.8.0`, `terraform/gke-helm/v1.3.0`.
+
+These tags are still valid and continue to resolve. However, Terraform's `git::` source handler passes the `ref` value through `go-getter`, which parses unencoded slashes as additional URL path segments and fails the lookup. Consumers pinning a legacy tag must URL-encode the slashes as `%2F`:
+
+```hcl
+module "polytomic" {
+  source = "git::https://github.com/polytomic/on-premises.git//terraform/modules/ecs?ref=terraform%2Fecs%2Fv2.8.0"
+}
+```
+
+New releases use the slash-free format above and do not require encoding:
+
+```hcl
+module "polytomic" {
+  source = "git::https://github.com/polytomic/on-premises.git//terraform/modules/ecs?ref=ecs-v2.9.0"
+}
+```
 
 ## Semantic Versioning
 
@@ -92,9 +116,21 @@ git push origin master
 ```
 
 ## 5. For Terraform only: Create and push tag
+
+Use the Makefile target in `terraform/`:
+
 ```bash
-git tag -a terraform/eks/v1.2.0 -m "Release EKS module v1.2.0"
-git push origin terraform/eks/v1.2.0
+cd terraform
+make release-tag MODULE=eks VERSION=1.2.0
+```
+
+This validates that you're on `master` with a clean tree, that the version appears in the module's CHANGELOG, creates the annotated tag in the `<module>-v<version>` format, and pushes it to `origin`.
+
+To create the tag manually:
+
+```bash
+git tag -a eks-v1.2.0 -m "Release EKS module v1.2.0"
+git push origin eks-v1.2.0
 ```
 
 ## 6. Update root CHANGELOG.md
@@ -102,7 +138,7 @@ Update the version number for your component:
 ```markdown
 #### EKS Infrastructure Module
 - **Current Version**: 1.2.0  ← Update this
-- **Latest Tag**: `terraform/eks/v1.2.0`  ← Update this
+- **Latest Tag**: `eks-v1.2.0`  ← Update this
 ```
 
 Commit and push:
@@ -126,13 +162,14 @@ Done!
 
 ```bash
 # What changed since last release?
-git log terraform/eks/v1.0.0..HEAD -- terraform/modules/eks/
+git log eks-v1.0.0..HEAD -- terraform/modules/eks/
 
 # See existing tags
-git tag -l "terraform/eks/*"
+git tag -l "eks-v*"
+git tag -l "terraform/eks/*"      # legacy
 git tag -l "polytomic-*"
 
 # Delete a tag (if you messed up)
-git tag -d terraform/eks/v1.2.0
-git push origin :refs/tags/terraform/eks/v1.2.0
+git tag -d eks-v1.2.0
+git push origin :refs/tags/eks-v1.2.0
 ```

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -29,4 +29,51 @@ scan:
 
 all: format generate-docs scan
 
-.PHONY: format generate-docs scan
+# Releasable modules are those with their own CHANGELOG.md.
+RELEASABLE_MODULES := $(sort $(notdir $(patsubst %/,%,$(dir $(wildcard modules/*/CHANGELOG.md)))))
+
+# Create an annotated release tag for a Terraform module.
+#
+# Usage:
+#   make release-tag MODULE=<name> VERSION=<x.y.z>
+# Example:
+#   make release-tag MODULE=ecs VERSION=2.9.0
+#
+# Produces a tag in the slash-free format `<module>-v<version>` (see ../VERSIONING.md).
+# The tag is created locally; push it with the command printed at the end.
+release-tag:
+	@if [ -z "$(MODULE)" ] || [ -z "$(VERSION)" ]; then \
+		echo "Usage: make release-tag MODULE=<name> VERSION=<x.y.z>"; \
+		echo "Example: make release-tag MODULE=ecs VERSION=2.9.0"; \
+		echo "Releasable modules: $(RELEASABLE_MODULES)"; \
+		exit 1; \
+	fi
+	@if ! echo "$(RELEASABLE_MODULES)" | tr ' ' '\n' | grep -qx "$(MODULE)"; then \
+		echo "Error: '$(MODULE)' is not a releasable module."; \
+		echo "Releasable modules: $(RELEASABLE_MODULES)"; \
+		exit 1; \
+	fi
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "Error: working tree is dirty; commit or stash changes before tagging"; \
+		exit 1; \
+	fi
+	@branch=$$(git rev-parse --abbrev-ref HEAD); \
+	if [ "$$branch" != "master" ]; then \
+		echo "Error: must be on master to tag a release (currently on $$branch)"; \
+		exit 1; \
+	fi
+	@if ! grep -qE "^## \[?$(VERSION)(\]| )" "modules/$(MODULE)/CHANGELOG.md"; then \
+		echo "Error: version $(VERSION) not found in modules/$(MODULE)/CHANGELOG.md"; \
+		echo "Add a CHANGELOG entry for this version before tagging."; \
+		exit 1; \
+	fi
+	@tag="$(MODULE)-v$(VERSION)"; \
+	if git rev-parse "$$tag" >/dev/null 2>&1; then \
+		echo "Error: tag $$tag already exists"; \
+		exit 1; \
+	fi; \
+	git tag -a "$$tag" -m "Release $(MODULE) module v$(VERSION)"; \
+	echo "Created tag $$tag"; \
+	echo "Push it with: git push origin $$tag"
+
+.PHONY: format generate-docs scan release-tag

--- a/terraform/modules/ecs/CHANGELOG.md
+++ b/terraform/modules/ecs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.8.0 (15 Apr 2026)
 
+> **Pinning this version:** this release is tagged `terraform/ecs/v2.8.0`. Terraform's `git::` source handler requires the slashes to be URL-encoded as `%2F` in the `ref=` value, e.g. `?ref=terraform%2Fecs%2Fv2.8.0`. Future releases use the slash-free format `ecs-v<version>` and do not require encoding. See [VERSIONING.md](../../../VERSIONING.md).
+
 ### Added
 
 - MCP server task definition, ECS service, ALB target group/listener rule, and associated variables for deploying the Polytomic MCP server on premises (#135).

--- a/terraform/modules/eks-helm/CHANGELOG.md
+++ b/terraform/modules/eks-helm/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.4.0] - 2026-04-27
 
+> **Pinning this version:** this release is tagged `terraform/eks-helm/v1.4.0`. Terraform's `git::` source handler requires the slashes to be URL-encoded as `%2F` in the `ref=` value, e.g. `?ref=terraform%2Feks-helm%2Fv1.4.0`. Future releases use the slash-free format `eks-helm-v<version>` and do not require encoding. See [VERSIONING.md](../../../VERSIONING.md).
+
 ### Added
 
 - **MCP server support**: Variables to enable and configure the Polytomic MCP server deployment, matching the support added to the ECS module in chart v1.4.0.

--- a/terraform/modules/gke-helm/CHANGELOG.md
+++ b/terraform/modules/gke-helm/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0] - 2026-04-27
 
+> **Pinning this version:** this release is tagged `terraform/gke-helm/v1.3.0`. Terraform's `git::` source handler requires the slashes to be URL-encoded as `%2F` in the `ref=` value, e.g. `?ref=terraform%2Fgke-helm%2Fv1.3.0`. Future releases use the slash-free format `gke-helm-v<version>` and do not require encoding. See [VERSIONING.md](../../../VERSIONING.md).
+
 ### Added
 
 - **MCP server support**: Variables to enable and configure the Polytomic MCP server deployment, matching the support added to the ECS module in chart v1.4.0.

--- a/terraform/modules/gke/CHANGELOG.md
+++ b/terraform/modules/gke/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.0] - 2026-04-27
 
+> **Pinning this version:** this release is tagged `terraform/gke/v1.2.0`. Terraform's `git::` source handler requires the slashes to be URL-encoded as `%2F` in the `ref=` value, e.g. `?ref=terraform%2Fgke%2Fv1.2.0`. Future releases use the slash-free format `gke-v<version>` and do not require encoding. See [VERSIONING.md](../../../VERSIONING.md).
+
 ### Added
 
 - **Managed SSL certificate provisioning**: The module now provisions a Google-managed SSL certificate alongside the static IP, removing the need for callers to declare a `google_compute_managed_ssl_certificate` resource in their root config.


### PR DESCRIPTION
Tags like `terraform/ecs/v2.8.0` require consumers to URL-encode the slashes (as `%2F`) when pinning via `git::` source `ref=`, since go-getter parses unencoded slashes as path segments. Going forward, terraform modules will be tagged `<module>-v<version>` (e.g. `ecs-v2.9.0`) to eliminate the encoding requirement.

- Update VERSIONING.md to document the new format and the legacy workaround for previously-released tags.
- Add a `make release-tag MODULE=<m> VERSION=<v>` target in terraform/Makefile that enforces the format, validates branch / cleanliness / CHANGELOG presence, and creates the annotated tag.
- Note the URL-encoding workaround in the current top entry of the ecs, eks-helm, gke-helm, and gke CHANGELOGs so consumers updating to the in-flight releases aren't surprised.