### PR TITLE
GKE module: make service-account creation opt-out

### DIFF
--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -193,9 +193,9 @@ module "polytomic-ecs" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0, < 6.0.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.27.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Resources
 

--- a/terraform/modules/eks-helm/README.md
+++ b/terraform/modules/eks-helm/README.md
@@ -9,8 +9,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.42.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 3.1.1 |
 
 ## Modules
 

--- a/terraform/modules/gke-helm/README.md
+++ b/terraform/modules/gke-helm/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 3.1.1 |
 
 ## Modules
 
@@ -73,4 +73,9 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_chart_version"></a> [chart\_version](#output\_chart\_version) | Deployed Helm chart version |
+| <a name="output_release_name"></a> [release\_name](#output\_release\_name) | Helm release name |
+| <a name="output_release_namespace"></a> [release\_namespace](#output\_release\_namespace) | Kubernetes namespace for the Helm release |
+| <a name="output_url"></a> [url](#output\_url) | Full Polytomic URL |

--- a/terraform/modules/gke/CHANGELOG.md
+++ b/terraform/modules/gke/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the GKE infrastructure module will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `create_cluster_service_account` variable (default `true`): opt out of the upstream `kubernetes-engine` module's cluster SA creation. Set to `false` when reusing a pre-bootstrapped node SA across many cluster workspaces in a single project, where the default would otherwise leave a dangling `tf-gke-*` SA per apply and require `iam.serviceAccountAdmin` on the project. Default preserves prior behavior.
+
 ## [1.2.0] - 2026-04-27
 
 > **Pinning this version:** this release is tagged `terraform/gke/v1.2.0`. Terraform's `git::` source handler requires the slashes to be URL-encoded as `%2F` in the `ref=` value, e.g. `?ref=terraform%2Fgke%2Fv1.2.0`. Future releases use the slash-free format `gke-v<version>` and do not require encoding. See [VERSIONING.md](../../../VERSIONING.md).

--- a/terraform/modules/gke/README.md
+++ b/terraform/modules/gke/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0, < 8.0.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.50.0 |
 
 ## Modules
 
@@ -46,7 +46,8 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The GCS bucket name to use. Must be globally unique. | `string` | `""` | no |
 | <a name="input_cluster_deletion_protection"></a> [cluster\_deletion\_protection](#input\_cluster\_deletion\_protection) | Whether to enable deletion protection on the GKE cluster | `bool` | `true` | no |
-| <a name="input_cluster_service_account"></a> [cluster\_service\_account](#input\_cluster\_service\_account) | The service account to use for the cluster | `string` | n/a | yes |
+| <a name="input_cluster_service_account"></a> [cluster\_service\_account](#input\_cluster\_service\_account) | Email of the service account the cluster's nodes run as. Required, and always used by the node pools regardless of create\_cluster\_service\_account. | `string` | n/a | yes |
+| <a name="input_create_cluster_service_account"></a> [create\_cluster\_service\_account](#input\_create\_cluster\_service\_account) | Whether to also have the upstream kubernetes-engine module create a tf-gke-* service account in project\_id during apply. Default true matches that module's default behavior; the created SA dangles unused because cluster\_service\_account is the one actually bound to the node pools. Set to false when the deploy identity lacks iam.serviceAccountAdmin on the project, or when sharing one pre-bootstrapped node SA across many cluster workspaces in a single project. | `bool` | `true` | no |
 | <a name="input_create_managed_certificate"></a> [create\_managed\_certificate](#input\_create\_managed\_certificate) | Provision Google-managed SSL certificates for polytomic\_url and (when set) polytomic\_mcp\_url. Set to false to bring your own certs. | `bool` | `true` | no |
 | <a name="input_create_postgres"></a> [create\_postgres](#input\_create\_postgres) | Whether to create a Cloud SQL PostgreSQL instance | `bool` | `true` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Whether to create a Memorystore Redis instance | `bool` | `true` | no |

--- a/terraform/modules/gke/main.tf
+++ b/terraform/modules/gke/main.tf
@@ -41,8 +41,9 @@ module "gke" {
   ip_range_pods     = var.ip_range_pods_name
   ip_range_services = var.ip_range_services_name
 
-  deletion_protection = var.cluster_deletion_protection
-  service_account     = var.cluster_service_account
+  deletion_protection    = var.cluster_deletion_protection
+  service_account        = var.cluster_service_account
+  create_service_account = var.create_cluster_service_account
 
   node_pools = [
     {

--- a/terraform/modules/gke/vars.tf
+++ b/terraform/modules/gke/vars.tf
@@ -22,8 +22,14 @@ variable "labels" {
 }
 
 variable "cluster_service_account" {
-  description = "The service account to use for the cluster"
+  description = "Email of the service account the cluster's nodes run as. Required, and always used by the node pools regardless of create_cluster_service_account."
   type        = string
+}
+
+variable "create_cluster_service_account" {
+  description = "Whether to also have the upstream kubernetes-engine module create a tf-gke-* service account in project_id during apply. Default true matches that module's default behavior; the created SA dangles unused because cluster_service_account is the one actually bound to the node pools. Set to false when the deploy identity lacks iam.serviceAccountAdmin on the project, or when sharing one pre-bootstrapped node SA across many cluster workspaces in a single project."
+  type        = bool
+  default     = true
 }
 
 # Ingress / TLS


### PR DESCRIPTION
The upstream `terraform-google-modules/kubernetes-engine` private-cluster module defaults `create_service_account = true`, which creates a `tf-gke-<name>-<rand>` SA in `project_id` on every apply. When the caller also supplies `service_account` (as this module always has — it's a required input), the created SA dangles: the node pools bind to the caller's SA, not the created one. See the comment at modules/private-cluster/sa.tf:28 in the upstream module.

That's already wasteful in the single-cluster case (it accumulates dead SAs and requires `iam.serviceAccountAdmin` on the deploy identity), and it's actively broken in the polytomic/app on-prem-gke-staging setup, where many PR-scoped cluster workspaces share one GCP project with a single pre-bootstrapped `pt-cluster-sa`. The deploy SA there is deliberately *not* granted `iam.serviceAccountAdmin`, so every apply 403s on the redundant create.

Add `create_cluster_service_account` (default `true`) and thread it through to the upstream module. Default behavior is unchanged; callers in the shared-project pattern can set it to `false` to skip the redundant create.