### PR TITLE
Bump ECS module Postgres default to 14.23

### DIFF
--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -289,7 +289,7 @@ module "polytomic-ecs" {
 | <a name="input_database_enabled_cloudwatch_logs_exports"></a> [database\_enabled\_cloudwatch\_logs\_exports](#input\_database\_enabled\_cloudwatch\_logs\_exports) | Database enabled cloudwatch logs exports | `list` | <pre>[<br/>  "postgresql",<br/>  "upgrade"<br/>]</pre> | no |
 | <a name="input_database_endpoint"></a> [database\_endpoint](#input\_database\_endpoint) | Database Endpoint | `string` | `""` | no |
 | <a name="input_database_engine"></a> [database\_engine](#input\_database\_engine) | Database engine | `string` | `"postgres"` | no |
-| <a name="input_database_engine_version"></a> [database\_engine\_version](#input\_database\_engine\_version) | Database engine version | `string` | `"14.15"` | no |
+| <a name="input_database_engine_version"></a> [database\_engine\_version](#input\_database\_engine\_version) | Database engine version | `string` | `"14.23"` | no |
 | <a name="input_database_family"></a> [database\_family](#input\_database\_family) | Database family | `string` | `"postgres14"` | no |
 | <a name="input_database_instance_class"></a> [database\_instance\_class](#input\_database\_instance\_class) | Database instance class | `string` | `"db.t3.small"` | no |
 | <a name="input_database_maintenance_window"></a> [database\_maintenance\_window](#input\_database\_maintenance\_window) | Database maintenance window | `string` | `"Mon:00:00-Mon:03:00"` | no |

--- a/terraform/modules/ecs/vars.tf
+++ b/terraform/modules/ecs/vars.tf
@@ -441,7 +441,7 @@ variable "database_auto_minor_version_upgrade" {
 
 variable "database_engine_version" {
   description = "Database engine version"
-  default     = "14.15"
+  default     = "14.23"
 }
 
 variable "database_family" {


### PR DESCRIPTION
AWS retired Postgres 14.15, so on-prem ECS sandbox deploys failed with "Cannot find version 14.15 for postgres" when creating the RDS instance. Default to the newest available 14.x minor instead.