### PR TITLE
Allow binding Vector DaemonSet to an existing ServiceAccount

### DIFF
--- a/helm/GCP-DEPLOYMENT.md
+++ b/helm/GCP-DEPLOYMENT.md
@@ -1,0 +1,216 @@
+# Deploying Polytomic on GCP / GKE
+
+This guide covers running the Polytomic Helm chart on Google Kubernetes Engine,
+with execution logs stored in Google Cloud Storage (GCS) and authentication via
+Workload Identity. It assumes you have already read the chart `README.md` and
+have a working install in mind.
+
+> If you are on **GKE Autopilot**, also review the `1.6.0` and `1.7.0` entries in
+> `charts/polytomic/CHANGELOG.md`: Autopilot requires
+> `polytomic.vector.daemonset.dataDir.type: emptyDir` (its admission controller
+> blocks write-mode `hostPath`) and per-role `ephemeral_storage_*` settings.
+
+## How logging works
+
+Polytomic emits structured execution logs to **stdout**. A **Vector DaemonSet**
+runs one pod per node, collects those lines from `/var/log/pods`, and ships them
+to the operational bucket. The app then **reads** them back out of the bucket to
+display and export logs in the UI.
+
+```
+app pods ──stdout──► Vector DaemonSet ──writes──► gs://<bucket>
+                                                          │
+   UI  ◄────────────── app reads/signs/exports ◄──────────┘
+```
+
+Two distinct identities touch the bucket, and **both** need write access on GCP:
+
+| Identity (KSA)        | Used by                                           | Bucket access it needs                              |
+| --------------------- | ------------------------------------------------- | --------------------------------------------------- |
+| App ServiceAccount    | web, worker, sync, scheduler, … and executor jobs | read + write + delete (`roles/storage.objectAdmin`) |
+| Vector ServiceAccount | the Vector DaemonSet only                         | write-only (`roles/storage.objectCreator`)          |
+
+The app reads, lists, signs, and deletes objects (serving logs in the UI,
+building exports, garbage-collecting), so it needs full object access. **Vector
+only ever creates new objects**, so object-create is sufficient.
+
+Grant these roles at the **bucket** level, as shown below. Do not scope IAM
+policy — or any external tooling — to specific object prefixes: the internal
+key layout is an implementation detail that changes between releases.
+
+## Required values
+
+```yaml
+polytomic:
+  s3:
+    gcs: true                          # select the GCS sinks in the Vector config
+    operational_bucket: "gs://my-operational-bucket"
+  vector:
+    daemonset:
+      enabled: true
+      dataDir:
+        type: emptyDir                 # required on GKE Autopilot
+```
+
+`operational_bucket` is the same bucket the app uses; `gcs: true` switches the
+Vector ConfigMap from the S3 sinks to the `gcp_cloud_storage` sinks.
+
+## Workload Identity setup
+
+On GCP there is **no credential env var** wired for the GCS sinks — Vector and the
+app both authenticate implicitly via Workload Identity. Each Kubernetes
+ServiceAccount (KSA) must be annotated to impersonate a Google ServiceAccount
+(GSA), and the GSA must be granted on the bucket.
+
+Set these once:
+
+```bash
+PROJECT=<your-project>
+NAMESPACE=<release-namespace>          # e.g. polytomic
+RELEASE=<helm-release-name>            # e.g. polytomic-prod
+BUCKET=<bucket-name>                   # no gs:// prefix
+```
+
+### App ServiceAccount
+
+The app KSA is `polytomic.serviceAccountName` — `<release>` by default, or
+whatever you set in `serviceAccount.name`.
+
+```bash
+APP_GSA=polytomic-app
+APP_KSA=$RELEASE                       # or your serviceAccount.name
+
+gcloud iam service-accounts create "$APP_GSA" --project="$PROJECT"
+
+gsutil iam ch \
+  "serviceAccount:${APP_GSA}@${PROJECT}.iam.gserviceaccount.com:roles/storage.objectAdmin" \
+  "gs://${BUCKET}"
+
+gcloud iam service-accounts add-iam-policy-binding \
+  "${APP_GSA}@${PROJECT}.iam.gserviceaccount.com" --project="$PROJECT" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:${PROJECT}.svc.id.goog[${NAMESPACE}/${APP_KSA}]"
+```
+
+```yaml
+serviceAccount:
+  create: true
+  annotations:
+    iam.gke.io/gcp-service-account: "polytomic-app@<project>.iam.gserviceaccount.com"
+```
+
+> If you manage the app ServiceAccount yourself (`serviceAccount.create: false`,
+> `serviceAccount.name: <existing>`), annotate that existing SA out-of-band
+> instead — the chart will not template annotations onto an SA it does not create.
+
+### Vector ServiceAccount
+
+Vector uses its **own** ServiceAccount, separate from the app. As of chart
+**1.8.0** you have three options:
+
+**Option A — dedicated, write-only GSA (recommended).** Vector is the highest-risk
+pod (runs as root, mounts the host `/var/log`, reads every pod's logs), so give it
+the narrowest possible identity:
+
+```bash
+VEC_GSA=polytomic-vector-logs
+VEC_KSA=${RELEASE}-vector              # chart-created name
+
+gcloud iam service-accounts create "$VEC_GSA" --project="$PROJECT" \
+  --display-name="Polytomic Vector log writer (write-only)"
+
+gsutil iam ch \
+  "serviceAccount:${VEC_GSA}@${PROJECT}.iam.gserviceaccount.com:roles/storage.objectCreator" \
+  "gs://${BUCKET}"
+
+gcloud iam service-accounts add-iam-policy-binding \
+  "${VEC_GSA}@${PROJECT}.iam.gserviceaccount.com" --project="$PROJECT" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:${PROJECT}.svc.id.goog[${NAMESPACE}/${VEC_KSA}]"
+```
+
+```yaml
+polytomic:
+  vector:
+    daemonset:
+      serviceAccount:
+        create: true
+        annotations:
+          iam.gke.io/gcp-service-account: "polytomic-vector-logs@<project>.iam.gserviceaccount.com"
+```
+
+**Option B — share an existing ServiceAccount.** If you already run all app pods
+under one Workload Identity SA and want Vector to reuse it, bind Vector to that SA
+by name. The chart points the daemonset **and** Vector's ClusterRoleBinding at the
+named SA, so it still receives the pod-log read permission Vector needs.
+
+```bash
+# Add the Vector KSA as a second authorized member of the existing GSA
+gcloud iam service-accounts add-iam-policy-binding \
+  "<existing-gsa>@${PROJECT}.iam.gserviceaccount.com" --project="$PROJECT" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:${PROJECT}.svc.id.goog[${NAMESPACE}/<existing-ksa>]"
+```
+
+```yaml
+polytomic:
+  vector:
+    daemonset:
+      serviceAccount:
+        create: false
+        name: <existing-ksa>           # e.g. the SA your app pods use
+```
+
+Sharing is simpler but over-privileges the daemonset if the shared GSA has roles
+beyond the operational bucket (KMS, Secret Manager, other buckets, …). Prefer
+Option A unless the shared GSA is itself scoped to just this bucket.
+
+**Option C — chart-created with the default name.** Omit `create`/`name` (defaults
+to `create: true`, name `<release>-vector`) and annotate as in Option A. This is
+the historical behavior.
+
+## Verify
+
+```bash
+# Annotations present on both SAs
+kubectl get sa "$RELEASE" -n "$NAMESPACE" -o jsonpath='{.metadata.annotations}'
+kubectl get sa "${RELEASE}-vector" -n "$NAMESPACE" -o jsonpath='{.metadata.annotations}'
+
+# From inside a Vector pod, the metadata server should return the bound GSA email
+POD=$(kubectl get pod -n "$NAMESPACE" -l app.kubernetes.io/name=polytomic-vector -o name | head -1)
+kubectl exec -n "$NAMESPACE" "$POD" -- wget -qO- \
+  --header="Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email"
+
+# Vector logs should be free of auth errors
+kubectl logs -n "$NAMESPACE" "$POD" | grep -E '403|implicit GCP token|dns error' || echo clean
+```
+
+## Troubleshooting
+
+**`ERROR ... 403 Forbidden` / `Not retriable; dropping the request` on a GCS sink.**
+Vector obtained a token but the identity it resolved to lacks
+`storage.objects.create` on the bucket. Causes, in order of likelihood:
+
+- The Vector KSA is not annotated with `iam.gke.io/gcp-service-account` (it fell
+  back to a default node identity). → annotate it (Options A–C above).
+- The GSA has no role on the bucket. → `gsutil iam ch …objectCreator gs://BUCKET`.
+- The Workload Identity member string is wrong. It is case-sensitive and exact:
+  `PROJECT.svc.id.goog[NAMESPACE/KSA]`. A typo here produces exactly this 403.
+
+**`ERROR ... Failed to get implicit GCP token: ... dns error: ... Try again`,
+followed by Vector restarting.** Vector cannot reach the metadata server
+(`metadata.google.internal`) to mint a token, so the sink fails to build and the
+pod crash-loops. Usually a symptom of the same broken Workload Identity path
+(transient during the crash-loop). Confirm Workload Identity is enabled on the
+node pool — on Autopilot it is by default; on Standard the node pool needs
+`--workload-metadata=GKE_METADATA`. Re-check after fixing the annotation/binding;
+bindings can take a minute or two to propagate.
+
+**The bucket has objects but the UI shows no execution logs.** The app and Vector
+use separate identities, so one can be healthy while the other is not. The app
+writes its own objects (exports, changeset data, probes) and reads everything
+back; Vector is the only writer of execution logs. So objects in the bucket
+confirm the app SA works, but say nothing about Vector — diagnose Vector
+independently via its pod logs and the metadata-server check above rather than by
+inspecting bucket contents.

--- a/helm/charts/polytomic/CHANGELOG.md
+++ b/helm/charts/polytomic/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Polytomic Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-06-17
+
+### Added
+
+- **Bring-your-own Vector ServiceAccount**: New `polytomic.vector.daemonset.serviceAccount.create` and `polytomic.vector.daemonset.serviceAccount.name` values let operators bind the Vector DaemonSet to an existing ServiceAccount instead of the chart-created `<release>-vector`. Set `create: false` and `name: <existing-sa>` to reuse a shared Workload Identity / IRSA ServiceAccount (for example the same SA the app pods use). The Vector ClusterRoleBinding follows the configured name, so the chosen SA still receives the pod-log read permission required by the `kubernetes_logs` source. Defaults (`create: true`, empty `name`) are unchanged and fully backward-compatible. This removes the prior asymmetry where the app ServiceAccount supported `create`/`name` but Vector's did not, forcing a separate Workload Identity binding on GKE.
+
+### Documentation
+
+- **GCP / GKE deployment guide**: Added `helm/GCP-DEPLOYMENT.md` covering execution logging to GCS, Workload Identity setup for both the app and Vector ServiceAccounts, the shared-vs-dedicated ServiceAccount trade-off, and troubleshooting for the `403 Forbidden` / `Failed to get implicit GCP token` Vector errors.
+
+---
+
 ## [1.7.0] - 2026-06-10
 
 ### Added

--- a/helm/charts/polytomic/Chart.yaml
+++ b/helm/charts/polytomic/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0
+version: 1.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/charts/polytomic/README.md
+++ b/helm/charts/polytomic/README.md
@@ -2,7 +2,7 @@
 
 Polytomic helm chart for kubernetes
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 ## Installing the Chart
 
@@ -63,6 +63,37 @@ polytomic:
 ```
 
 Note: S3 configuration is currently required even when using Datadog, as the S3 sink is always enabled in the Vector config.
+
+### Execution Logs to GCS (GKE)
+
+On GKE, set `polytomic.s3.gcs: true` to route logs to a GCS bucket and authenticate
+both the app and Vector ServiceAccounts via Workload Identity. The Vector
+ServiceAccount supports `create` and `name`, so you can either let the chart create
+it (and annotate it) or bind Vector to an existing ServiceAccount:
+
+```yaml
+polytomic:
+  s3:
+    gcs: true
+    operational_bucket: "gs://your-bucket"
+  vector:
+    daemonset:
+      enabled: true
+      dataDir:
+        type: emptyDir          # required on GKE Autopilot
+      serviceAccount:
+        # Option A: chart-created, dedicated SA (recommended)
+        create: true
+        annotations:
+          iam.gke.io/gcp-service-account: "vector-logs@my-project.iam.gserviceaccount.com"
+        # Option B: reuse an existing SA (e.g. a shared Workload Identity SA)
+        # create: false
+        # name: my-existing-sa
+```
+
+See [`GCP-DEPLOYMENT.md`](../../GCP-DEPLOYMENT.md) for the full Workload Identity
+setup, the shared-vs-dedicated ServiceAccount trade-off, and troubleshooting for
+`403 Forbidden` / `Failed to get implicit GCP token` Vector errors.
 
 ## Redis Configuration
 
@@ -290,7 +321,7 @@ externalRedis:
 | polytomic.sync_workers | int | `10` |  |
 | polytomic.tracing | bool | `false` |  |
 | polytomic.tx_buffer_size | int | `1000` |  |
-| polytomic.vector.daemonset | object | `{"affinity":{},"dataDir":{"type":"hostPath"},"enabled":true,"image":"polytomic-vector","imagePullPolicy":"IfNotPresent","nodeSelector":{},"podLabelSelector":"vector.dev/include=true","resources":{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}},"serviceAccount":{"annotations":{},"roleArn":""},"tag":"","tolerations":[]}` | Vector DaemonSet for stdout/stderr log collection Collects container logs from all Polytomic pods on each node Default: true (matches ECS behavior where polytomic_use_logger defaults to true) |
+| polytomic.vector.daemonset | object | `{"affinity":{},"dataDir":{"type":"hostPath"},"enabled":true,"image":"polytomic-vector","imagePullPolicy":"IfNotPresent","nodeSelector":{},"podLabelSelector":"vector.dev/include=true","resources":{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}},"serviceAccount":{"annotations":{},"create":true,"name":"","roleArn":""},"tag":"","tolerations":[]}` | Vector DaemonSet for stdout/stderr log collection Collects container logs from all Polytomic pods on each node Default: true (matches ECS behavior where polytomic_use_logger defaults to true) |
 | polytomic.vector.daemonset.affinity | object | `{}` | Affinity rules for Vector DaemonSet pods |
 | polytomic.vector.daemonset.dataDir | object | `{"type":"hostPath"}` | Volume backing Vector's data_dir (/var/lib/vector), which holds the kubernetes_logs source checkpoints. |
 | polytomic.vector.daemonset.dataDir.type | string | `"hostPath"` | "hostPath" or "emptyDir". hostPath (default) persists checkpoints across pod reschedules on a node. GKE Autopilot blocks write-mode hostPath (autogke-no-write-mode-hostpath), so set this to "emptyDir" on Autopilot. With emptyDir, checkpoints live only for the pod's lifetime; a reschedule may re-read recent node logs. |
@@ -298,8 +329,10 @@ externalRedis:
 | polytomic.vector.daemonset.image | string | `"polytomic-vector"` | Image name for Vector DaemonSet (registry is set via imageRegistry). MUST use Polytomic's Vector image with ptconf for secret decryption. |
 | polytomic.vector.daemonset.nodeSelector | object | `{}` | Node selector for Vector DaemonSet pods |
 | polytomic.vector.daemonset.podLabelSelector | string | `"vector.dev/include=true"` | Label selector to filter which pods to collect logs from. Uses vector.dev/include=true which is set on all Polytomic pod templates, making collection independent of the Helm release name. |
-| polytomic.vector.daemonset.serviceAccount | object | `{"annotations":{},"roleArn":""}` | ServiceAccount configuration for Vector DaemonSet |
-| polytomic.vector.daemonset.serviceAccount.annotations | object | `{}` | Additional service account annotations (for example GKE Workload Identity) |
+| polytomic.vector.daemonset.serviceAccount | object | `{"annotations":{},"create":true,"name":"","roleArn":""}` | ServiceAccount configuration for Vector DaemonSet |
+| polytomic.vector.daemonset.serviceAccount.annotations | object | `{}` | Additional service account annotations (for example GKE Workload Identity). Only applied when create is true; annotate an existing SA out-of-band. |
+| polytomic.vector.daemonset.serviceAccount.create | bool | `true` | Create the Vector ServiceAccount. Set to false to bind Vector to an existing ServiceAccount (for example a shared Workload Identity SA). |
+| polytomic.vector.daemonset.serviceAccount.name | string | `""` | Name of the ServiceAccount. Required when create is false; when create is true and left empty, defaults to "<release>-vector". |
 | polytomic.vector.daemonset.serviceAccount.roleArn | string | `""` | IAM role ARN for IRSA (EKS only) |
 | polytomic.vector.daemonset.tag | string | `""` | Tag for the Vector image. Defaults to image.tag when not set. |
 | polytomic.vector.daemonset.tolerations | list | `[]` | Additional tolerations for the Vector DaemonSet pods. By default no tolerations are set, so Vector only runs on schedulable worker nodes. Add tolerations here if your nodes have custom taints that Polytomic pods also tolerate. |

--- a/helm/charts/polytomic/README.md.gotmpl
+++ b/helm/charts/polytomic/README.md.gotmpl
@@ -56,6 +56,37 @@ polytomic:
 
 Note: S3 configuration is currently required even when using Datadog, as the S3 sink is always enabled in the Vector config.
 
+### Execution Logs to GCS (GKE)
+
+On GKE, set `polytomic.s3.gcs: true` to route logs to a GCS bucket and authenticate
+both the app and Vector ServiceAccounts via Workload Identity. The Vector
+ServiceAccount supports `create` and `name`, so you can either let the chart create
+it (and annotate it) or bind Vector to an existing ServiceAccount:
+
+```yaml
+polytomic:
+  s3:
+    gcs: true
+    operational_bucket: "gs://your-bucket"
+  vector:
+    daemonset:
+      enabled: true
+      dataDir:
+        type: emptyDir          # required on GKE Autopilot
+      serviceAccount:
+        # Option A: chart-created, dedicated SA (recommended)
+        create: true
+        annotations:
+          iam.gke.io/gcp-service-account: "vector-logs@my-project.iam.gserviceaccount.com"
+        # Option B: reuse an existing SA (e.g. a shared Workload Identity SA)
+        # create: false
+        # name: my-existing-sa
+```
+
+See [`GCP-DEPLOYMENT.md`](../../GCP-DEPLOYMENT.md) for the full Workload Identity
+setup, the shared-vs-dedicated ServiceAccount trade-off, and troubleshooting for
+`403 Forbidden` / `Failed to get implicit GCP token` Vector errors.
+
 ## Redis Configuration
 
 Polytomic supports both single-node Redis and Redis Cluster mode.

--- a/helm/charts/polytomic/templates/_helpers.tpl
+++ b/helm/charts/polytomic/templates/_helpers.tpl
@@ -155,6 +155,21 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the Vector DaemonSet service account to use.
+When create is true, defaults to "<fullname>-vector". When create is
+false, an explicit name is required so the operator can point Vector at
+an existing (for example Workload Identity) ServiceAccount.
+*/}}
+{{- define "polytomic.vector.serviceAccountName" -}}
+{{- $sa := .Values.polytomic.vector.daemonset.serviceAccount -}}
+{{- if $sa.create -}}
+{{- default (printf "%s-vector" (include "polytomic.fullname" .)) $sa.name -}}
+{{- else -}}
+{{- required "polytomic.vector.daemonset.serviceAccount.name is required when serviceAccount.create is false" $sa.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Get PostgreSQL host
 */}}
 {{- define "polytomic.postgresql.host" -}}

--- a/helm/charts/polytomic/templates/vector-clusterrolebinding.yaml
+++ b/helm/charts/polytomic/templates/vector-clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: vector
 subjects:
 - kind: ServiceAccount
-  name: {{ include "polytomic.fullname" . }}-vector
+  name: {{ include "polytomic.vector.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/helm/charts/polytomic/templates/vector-daemonset.yaml
+++ b/helm/charts/polytomic/templates/vector-daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         app.kubernetes.io/name: {{ include "polytomic.name" . }}-vector
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ include "polytomic.fullname" . }}-vector
+      serviceAccountName: {{ include "polytomic.vector.serviceAccountName" . }}
       # Vector must run as root to read /var/log/pods from the host.
       # No securityContext override is provided; the default (root) is required.
       initContainers:

--- a/helm/charts/polytomic/templates/vector-serviceaccount.yaml
+++ b/helm/charts/polytomic/templates/vector-serviceaccount.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.polytomic.vector.daemonset.enabled }}
+{{- if and .Values.polytomic.vector.daemonset.enabled .Values.polytomic.vector.daemonset.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "polytomic.fullname" . }}-vector
+  name: {{ include "polytomic.vector.serviceAccountName" . }}
   labels:
     {{- include "polytomic.labels" . | nindent 4 }}
     app.kubernetes.io/component: vector

--- a/helm/charts/polytomic/values.yaml
+++ b/helm/charts/polytomic/values.yaml
@@ -314,7 +314,14 @@ polytomic:
 
       # -- ServiceAccount configuration for Vector DaemonSet
       serviceAccount:
-        # -- Additional service account annotations (for example GKE Workload Identity)
+        # -- Create the Vector ServiceAccount. Set to false to bind Vector to
+        # an existing ServiceAccount (for example a shared Workload Identity SA).
+        create: true
+        # -- Name of the ServiceAccount. Required when create is false; when
+        # create is true and left empty, defaults to "<release>-vector".
+        name: ""
+        # -- Additional service account annotations (for example GKE Workload Identity).
+        # Only applied when create is true; annotate an existing SA out-of-band.
         annotations: {}
         # -- IAM role ARN for IRSA (EKS only)
         roleArn: ""


### PR DESCRIPTION
The app ServiceAccount supported create/name, but Vector's name was hardcoded and always created. On GKE this forced a separate Workload Identity binding for Vector even when a suitable ServiceAccount already existed, and left no way to reuse a shared identity.

Add polytomic.vector.daemonset.serviceAccount.create and .name, routed through a helper used by the DaemonSet, the ServiceAccount, and the ClusterRoleBinding so the chosen SA still receives the pod-log read permission the kubernetes_logs source needs. Defaults are unchanged.

Add helm/GCP-DEPLOYMENT.md documenting GCS logging, Workload Identity for both ServiceAccounts, the shared-vs-dedicated trade-off, and the 403 / implicit-token Vector errors. Bump chart to 1.8.0.